### PR TITLE
Add marine weather data sources

### DIFF
--- a/app/src/main/kotlin/com/jjswigut/eventide/data/models/MarineConditions.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/data/models/MarineConditions.kt
@@ -1,0 +1,40 @@
+package com.jjswigut.eventide.data.models
+
+data class MarineConditions(
+    val observations: List<MarineObservation> = emptyList(),
+    val alerts: List<MarineAlert> = emptyList(),
+    val buoy: BuoyConditions? = null,
+    val waveForecast: WaveForecast? = null,
+) {
+    val hasData: Boolean
+        get() = observations.isNotEmpty() || alerts.isNotEmpty() || buoy != null || waveForecast != null
+}
+
+data class MarineObservation(
+    val label: String,
+    val value: String,
+)
+
+data class MarineAlert(
+    val event: String,
+    val headline: String,
+    val severity: String,
+)
+
+data class BuoyConditions(
+    val stationId: String,
+    val stationName: String,
+    val distanceMiles: Double,
+    val wind: String? = null,
+    val waveHeight: String? = null,
+    val wavePeriod: String? = null,
+    val waterTemperature: String? = null,
+    val pressure: String? = null,
+)
+
+data class WaveForecast(
+    val waveHeight: String? = null,
+    val wavePeriod: String? = null,
+    val seaSurfaceTemperature: String? = null,
+    val attribution: String = "Open-Meteo Marine",
+)

--- a/app/src/main/kotlin/com/jjswigut/eventide/map/MapScreen.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/map/MapScreen.kt
@@ -40,6 +40,7 @@ import com.jjswigut.eventide.map.MapAction.SetTideAlertLeadTime
 import com.jjswigut.eventide.map.MapAction.SetTideUnit
 import com.jjswigut.eventide.map.MapAction.SetTimeFormat
 import com.jjswigut.eventide.map.MapAction.ToggleRadarOverlay
+import com.jjswigut.eventide.map.MapAction.ToggleSatelliteOverlay
 import com.jjswigut.eventide.map.MapAction.ToggleTideAlert
 import com.jjswigut.eventide.map.MapAction.ToggleWeatherOverlay
 import com.jjswigut.eventide.map.components.FavoritesPanel
@@ -72,6 +73,12 @@ fun MapScreen(
         WmsTileProvider(
             baseUrl = "https://mapservices.weather.noaa.gov/geoserver/ndfd/sky/ows",
             layers = "sky",
+        )
+    }
+    val satelliteTileProvider = remember {
+        WmsTileProvider(
+            baseUrl = "https://nowcoast.noaa.gov/geoserver/observations/satellite/ows",
+            layers = "goes_longwave_imagery",
         )
     }
 
@@ -150,6 +157,14 @@ fun MapScreen(
                 )
             }
 
+            if (viewState.isSatelliteOverlayEnabled) {
+                TileOverlay(
+                    tileProvider = satelliteTileProvider,
+                    transparency = SATELLITE_OVERLAY_TRANSPARENCY,
+                    zIndex = SATELLITE_OVERLAY_Z_INDEX,
+                )
+            }
+
             EventideClustering(
                 items = viewState.stations,
                 onClusterClick = onClusterClick,
@@ -178,6 +193,8 @@ fun MapScreen(
             StationInfoRow(
                 modifier = Modifier.align(Alignment.Center),
                 list = tideDays,
+                marineConditions = viewState.marineConditions,
+                isMarineConditionsLoading = viewState.isMarineConditionsLoading,
                 station = viewState.selectedStation,
                 isFavorite = viewState.isSelectedStationFavorite,
                 settings = viewState.settings,
@@ -192,6 +209,7 @@ fun MapScreen(
             selectedActions = buildSet {
                 if (viewState.isRadarOverlayEnabled) add(ToggleRadarOverlay)
                 if (viewState.isWeatherOverlayEnabled) add(ToggleWeatherOverlay)
+                if (viewState.isSatelliteOverlayEnabled) add(ToggleSatelliteOverlay)
             },
             actionHandler = { action ->
                 when (action) {
@@ -208,6 +226,14 @@ fun MapScreen(
                             "Weather has been disabled"
                         } else {
                             "Weather has been enabled"
+                        }
+                        Toast.makeText(context, toggleMessage, Toast.LENGTH_SHORT).show()
+                    }
+                    ToggleSatelliteOverlay -> {
+                        val toggleMessage = if (viewState.isSatelliteOverlayEnabled) {
+                            "Clouds have been disabled"
+                        } else {
+                            "Clouds have been enabled"
                         }
                         Toast.makeText(context, toggleMessage, Toast.LENGTH_SHORT).show()
                     }
@@ -286,8 +312,10 @@ fun MapScreen(
 private const val CLUSTER_ZOOM_PADDING = 150
 private const val WEATHER_OVERLAY_TRANSPARENCY = 0.35f
 private const val RADAR_OVERLAY_TRANSPARENCY = 0.15f
+private const val SATELLITE_OVERLAY_TRANSPARENCY = 0.45f
 private const val WEATHER_OVERLAY_Z_INDEX = 1f
 private const val RADAR_OVERLAY_Z_INDEX = 2f
+private const val SATELLITE_OVERLAY_Z_INDEX = 3f
 
 fun Cluster<*>.clusterZoomCameraUpdate(): CameraUpdate {
     val latLngBoundsBuilder = LatLngBounds.Builder()

--- a/app/src/main/kotlin/com/jjswigut/eventide/map/MapViewModel.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/map/MapViewModel.kt
@@ -12,6 +12,7 @@ import com.google.android.gms.maps.model.LatLngBounds
 import com.google.maps.android.compose.CameraPositionState
 import com.jjswigut.eventide.R
 import com.jjswigut.eventide.alerts.TideAlertScheduler
+import com.jjswigut.eventide.data.models.MarineConditions
 import com.jjswigut.eventide.data.models.Station
 import com.jjswigut.eventide.data.models.TideAlertFilter
 import com.jjswigut.eventide.data.models.TideAlertPreference
@@ -40,6 +41,7 @@ import com.jjswigut.eventide.map.MapAction.SetTideUnit
 import com.jjswigut.eventide.map.MapAction.SetTimeFormat
 import com.jjswigut.eventide.map.MapAction.ToggleFavorite
 import com.jjswigut.eventide.map.MapAction.ToggleRadarOverlay
+import com.jjswigut.eventide.map.MapAction.ToggleSatelliteOverlay
 import com.jjswigut.eventide.map.MapAction.ToggleTideAlert
 import com.jjswigut.eventide.map.MapAction.ToggleWeatherOverlay
 import com.jjswigut.eventide.map.models.StationClusterItem
@@ -93,6 +95,11 @@ private val listOfButtons = persistentListOf(
         text = "Weather",
         iconRes = R.drawable.weather_overlay,
         action = ToggleWeatherOverlay,
+    ),
+    MenuItem(
+        text = "Clouds",
+        iconRes = R.drawable.weather_overlay,
+        action = ToggleSatelliteOverlay,
     ),
 )
 
@@ -158,6 +165,8 @@ class MapViewModel(
                     updateViewState {
                         copy(
                             listOfTideDays = null,
+                            marineConditions = null,
+                            isMarineConditionsLoading = false,
                             selectedStation = null,
                             isSelectedStationFavorite = false,
                             showEmptyState = stations.isEmpty() && isMapLoaded,
@@ -237,6 +246,14 @@ class MapViewModel(
                     updateViewState {
                         copy(
                             isWeatherOverlayEnabled = !isWeatherOverlayEnabled,
+                            menuState = menuState.copy(expanded = false),
+                        )
+                    }
+                }
+                is ToggleSatelliteOverlay -> {
+                    updateViewState {
+                        copy(
+                            isSatelliteOverlayEnabled = !isSatelliteOverlayEnabled,
                             menuState = menuState.copy(expanded = false),
                         )
                     }
@@ -367,6 +384,8 @@ class MapViewModel(
                 listOfTideDays = placeholderCards.toImmutableList(),
                 selectedStation = station,
                 isSelectedStationFavorite = favorites.any { it.id == stationId },
+                marineConditions = null,
+                isMarineConditionsLoading = true,
                 showEmptyState = false,
                 showFavorites = false,
                 showSettings = false,
@@ -410,9 +429,33 @@ class MapViewModel(
                             },
                         )
                     }
+
+                    launch(dispatcher.io) {
+                        noaaRepository.getMarineConditionsForStation(stationId).process(
+                            onSuccess = { marineConditions ->
+                                updateViewState {
+                                    copy(
+                                        marineConditions = marineConditions.takeIf { it.hasData },
+                                        isMarineConditionsLoading = false,
+                                    )
+                                }
+                            },
+                            onError = {
+                                updateViewState {
+                                    copy(
+                                        marineConditions = null,
+                                        isMarineConditionsLoading = false,
+                                    )
+                                }
+                            },
+                        )
+                    }
                 },
                 onError = {
                     // todo add kermit logging
+                    updateViewState {
+                        copy(isMarineConditionsLoading = false)
+                    }
                 },
             )
         }
@@ -672,6 +715,8 @@ class MapViewModel(
             isMapLoaded = false,
             showEmptyState = false,
             listOfTideDays = null,
+            marineConditions = null,
+            isMarineConditionsLoading = false,
             selectedStation = null,
             isSelectedStationFavorite = false,
             favorites = persistentListOf(),
@@ -681,6 +726,7 @@ class MapViewModel(
             showSettings = false,
             isRadarOverlayEnabled = false,
             isWeatherOverlayEnabled = false,
+            isSatelliteOverlayEnabled = false,
             menuState = MenuState(
                 centerButton = mainButton,
                 outsideButtons = listOfButtons,
@@ -708,6 +754,8 @@ data class MapViewState(
     val showEmptyState: Boolean,
     val stations: ImmutableList<StationClusterItem>,
     val listOfTideDays: ImmutableList<TideDay>?,
+    val marineConditions: MarineConditions?,
+    val isMarineConditionsLoading: Boolean,
     val selectedStation: Station?,
     val isSelectedStationFavorite: Boolean,
     val favorites: ImmutableList<Station>,
@@ -717,6 +765,7 @@ data class MapViewState(
     val showSettings: Boolean,
     val isRadarOverlayEnabled: Boolean,
     val isWeatherOverlayEnabled: Boolean,
+    val isSatelliteOverlayEnabled: Boolean,
     val menuState: MenuState,
 )
 
@@ -749,6 +798,7 @@ sealed interface MapAction : Action {
     data object CloseSettings : MapAction
     data object ToggleRadarOverlay : MapAction
     data object ToggleWeatherOverlay : MapAction
+    data object ToggleSatelliteOverlay : MapAction
 
     data object CloseTides : MapAction
 

--- a/app/src/main/kotlin/com/jjswigut/eventide/map/components/StationInfoRow.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/map/components/StationInfoRow.kt
@@ -9,29 +9,41 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.jjswigut.eventide.R
+import com.jjswigut.eventide.data.models.MarineConditions
 import com.jjswigut.eventide.data.models.Station
 import com.jjswigut.eventide.data.models.TideDay
 import com.jjswigut.eventide.map.MapAction
 import com.jjswigut.eventide.settings.AppSettings
 import com.jjswigut.eventide.ui.components.Action
+import com.jjswigut.eventide.ui.components.BodyText
+import com.jjswigut.eventide.ui.components.SectionTitleText
+import com.jjswigut.eventide.ui.components.ShimmerLoading
+import com.jjswigut.eventide.ui.theme.BackgroundDark
 import com.jjswigut.eventide.ui.theme.Primary
 import com.jjswigut.eventide.ui.theme.PrimaryDark
 import com.jjswigut.eventide.ui.theme.PrimaryLight
+import java.util.Locale
 
 private object StationInfoDesign {
     val closeButtonSize = 48.dp
@@ -42,12 +54,17 @@ private object StationInfoDesign {
 
     val cardSpacing = 16.dp
     val cardPadding = 16.dp
+    val marinePanelCornerRadius = 12.dp
+    val marinePanelPadding = 12.dp
+    val marineChipCornerRadius = 8.dp
 }
 
 @Composable
 fun StationInfoRow(
     modifier: Modifier = Modifier,
     list: List<TideDay>,
+    marineConditions: MarineConditions?,
+    isMarineConditionsLoading: Boolean,
     station: Station?,
     isFavorite: Boolean,
     settings: AppSettings,
@@ -68,8 +85,137 @@ fun StationInfoRow(
             )
         }
 
+        MarineSummary(
+            marineConditions = marineConditions,
+            isLoading = isMarineConditionsLoading,
+        )
+
         TideCardList(list = list, settings = settings)
     }
+}
+
+@Composable
+private fun MarineSummary(
+    marineConditions: MarineConditions?,
+    isLoading: Boolean,
+) {
+    if (!isLoading && marineConditions == null) return
+
+    val boxWidth = LocalConfiguration.current.screenWidthDp - 48
+
+    Column(
+        modifier = Modifier
+            .padding(
+                start = StationInfoDesign.cardPadding,
+                end = StationInfoDesign.cardPadding,
+                bottom = StationInfoDesign.cardSpacing,
+            )
+            .width(boxWidth.dp)
+            .background(
+                color = BackgroundDark.copy(alpha = 0.85f),
+                shape = RoundedCornerShape(StationInfoDesign.marinePanelCornerRadius),
+            )
+            .border(
+                width = 1.dp,
+                color = PrimaryLight.copy(alpha = 0.6f),
+                shape = RoundedCornerShape(StationInfoDesign.marinePanelCornerRadius),
+            )
+            .padding(StationInfoDesign.marinePanelPadding),
+    ) {
+        SectionTitleText(
+            text = "Marine conditions",
+            color = Color.White,
+        )
+
+        if (isLoading) {
+            ShimmerLoading(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+            )
+            return@Column
+        }
+
+        val conditions = marineConditions ?: return@Column
+        val chips = remember(conditions) { conditions.toMarineChips() }
+
+        conditions.alerts.firstOrNull()?.let { alert ->
+            Text(
+                modifier = Modifier.padding(top = 8.dp),
+                text = "${alert.event}: ${alert.severity}",
+                color = Color(0xFFFFD166),
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            BodyText(
+                text = alert.headline,
+                color = Color.White,
+                maxLines = 2,
+            )
+        }
+
+        if (chips.isNotEmpty()) {
+            LazyRow(
+                modifier = Modifier.padding(top = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(chips) { chip ->
+                    MarineChip(chip)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MarineChip(text: String) {
+    Text(
+        modifier = Modifier
+            .background(
+                color = PrimaryLight.copy(alpha = 0.25f),
+                shape = RoundedCornerShape(StationInfoDesign.marineChipCornerRadius),
+            )
+            .padding(horizontal = 10.dp, vertical = 6.dp),
+        text = text,
+        color = Color.White,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+    )
+}
+
+private fun MarineConditions.toMarineChips(): List<String> {
+    val chips = mutableListOf<String>()
+    observations.take(4).forEach { observation ->
+        chips += "${observation.label}: ${observation.value}"
+    }
+    buoy?.let { buoy ->
+        val distance = String.format(Locale.US, "%.0f", buoy.distanceMiles)
+        val details = listOfNotNull(
+            buoy.waveHeight?.let { "waves $it" },
+            buoy.wind?.let { "wind $it" },
+            buoy.waterTemperature?.let { "water $it" },
+        ).joinToString(", ")
+        chips += if (details.isBlank()) {
+            "Buoy ${buoy.stationId}: ${distance}mi"
+        } else {
+            "Buoy ${buoy.stationId}: $details"
+        }
+    }
+    waveForecast?.let { forecast ->
+        val details = listOfNotNull(
+            forecast.waveHeight?.let { "waves $it" },
+            forecast.wavePeriod?.let { "period $it" },
+            forecast.seaSurfaceTemperature?.let { "SST $it" },
+        ).joinToString(", ")
+        if (details.isNotBlank()) {
+            chips += "${forecast.attribution}: $details"
+        }
+    }
+    if (alerts.size > 1) {
+        chips += "${alerts.size} active alerts"
+    }
+    return chips
 }
 
 @Composable

--- a/app/src/main/kotlin/com/jjswigut/eventide/network/NetworkModule.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/network/NetworkModule.kt
@@ -1,7 +1,10 @@
 package com.jjswigut.eventide.network
 
+import com.jjswigut.eventide.network.client.MarineServiceClient
 import com.jjswigut.eventide.network.client.NoaaServiceClient
 import com.jjswigut.eventide.network.client.WeatherServiceClient
+import com.jjswigut.eventide.network.service.MarineService
+import com.jjswigut.eventide.network.service.MarineServiceImpl
 import com.jjswigut.eventide.network.service.NoaaService
 import com.jjswigut.eventide.network.service.NoaaServiceImpl
 import com.jjswigut.eventide.network.service.WeatherService
@@ -28,6 +31,20 @@ val networkModule = module {
     single<WeatherService> {
         WeatherServiceImpl(
             client = WeatherServiceClient(
+                OkHttp.create {
+                    config {
+                        connectTimeout(timeout.toLong(), TimeUnit.MILLISECONDS)
+                        readTimeout(timeout.toLong(), TimeUnit.MILLISECONDS)
+                        writeTimeout(timeout.toLong(), TimeUnit.MILLISECONDS)
+                    }
+                },
+            ),
+        )
+    }
+
+    single<MarineService> {
+        MarineServiceImpl(
+            client = MarineServiceClient(
                 OkHttp.create {
                     config {
                         connectTimeout(timeout.toLong(), TimeUnit.MILLISECONDS)

--- a/app/src/main/kotlin/com/jjswigut/eventide/network/client/MarineServiceClient.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/network/client/MarineServiceClient.kt
@@ -1,0 +1,71 @@
+package com.jjswigut.eventide.network.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.client.request.url
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+class MarineServiceClient(engine: HttpClientEngine) {
+    private val client = HttpClient(engine) {
+        install(ContentNegotiation) {
+            json(
+                Json {
+                    ignoreUnknownKeys = true
+                },
+            )
+        }
+        defaultRequest {
+            header("User-Agent", "Eventide/1.0 (jjswigut@gmail.com)")
+        }
+    }
+
+    suspend fun getCoopsLatestObservation(
+        stationId: String,
+        product: String,
+    ) = client.get {
+        url("$COOPS_BASE_URL/api/prod/datagetter")
+        parameter("date", "latest")
+        parameter("station", stationId)
+        parameter("product", product)
+        parameter("time_zone", "lst_ldt")
+        parameter("units", "english")
+        parameter("application", "Eventide")
+        parameter("format", "json")
+    }
+
+    suspend fun getActiveAlerts(
+        latitude: Double,
+        longitude: Double,
+    ) = client.get("$NWS_BASE_URL/alerts/active?point=$latitude,$longitude")
+
+    suspend fun getNdbcActiveStations() = client.get("$NDBC_BASE_URL/activestations.xml")
+
+    suspend fun getNdbcRealtimeText(stationId: String) = client.get("$NDBC_BASE_URL/data/realtime2/$stationId.txt")
+
+    suspend fun getOpenMeteoMarine(
+        latitude: Double,
+        longitude: Double,
+    ) = client.get {
+        url("$OPEN_METEO_MARINE_BASE_URL/v1/marine")
+        parameter("latitude", latitude)
+        parameter("longitude", longitude)
+        parameter("current", "wave_height,wave_period,sea_surface_temperature")
+        parameter("length_unit", "imperial")
+        parameter("temperature_unit", "fahrenheit")
+        parameter("timezone", "auto")
+        parameter("cell_selection", "sea")
+    }
+
+    companion object {
+        private const val COOPS_BASE_URL = "https://api.tidesandcurrents.noaa.gov"
+        private const val NWS_BASE_URL = "https://api.weather.gov"
+        private const val NDBC_BASE_URL = "https://www.ndbc.noaa.gov"
+        private const val OPEN_METEO_MARINE_BASE_URL = "https://marine-api.open-meteo.com"
+    }
+}

--- a/app/src/main/kotlin/com/jjswigut/eventide/network/responses/MarineResponse.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/network/responses/MarineResponse.kt
@@ -1,0 +1,36 @@
+package com.jjswigut.eventide.network.responses
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NwsAlertsResponse(
+    val features: List<NwsAlertFeature> = emptyList(),
+)
+
+@Serializable
+data class NwsAlertFeature(
+    val properties: NwsAlertProperties,
+)
+
+@Serializable
+data class NwsAlertProperties(
+    val event: String? = null,
+    val headline: String? = null,
+    val severity: String? = null,
+)
+
+@Serializable
+data class OpenMeteoMarineResponse(
+    val current: OpenMeteoMarineCurrent? = null,
+)
+
+@Serializable
+data class OpenMeteoMarineCurrent(
+    @SerialName("wave_height")
+    val waveHeight: Double? = null,
+    @SerialName("wave_period")
+    val wavePeriod: Double? = null,
+    @SerialName("sea_surface_temperature")
+    val seaSurfaceTemperature: Double? = null,
+)

--- a/app/src/main/kotlin/com/jjswigut/eventide/network/service/MarineService.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/network/service/MarineService.kt
@@ -1,0 +1,13 @@
+package com.jjswigut.eventide.network.service
+
+import com.jjswigut.eventide.data.models.MarineConditions
+import com.jjswigut.eventide.network.utils.Either
+import com.jjswigut.eventide.utils.GenericError
+
+interface MarineService {
+    suspend fun getMarineConditions(
+        stationId: String,
+        latitude: Double,
+        longitude: Double,
+    ): Either<MarineConditions, GenericError>
+}

--- a/app/src/main/kotlin/com/jjswigut/eventide/network/service/MarineServiceImpl.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/network/service/MarineServiceImpl.kt
@@ -1,0 +1,321 @@
+package com.jjswigut.eventide.network.service
+
+import com.jjswigut.eventide.data.models.BuoyConditions
+import com.jjswigut.eventide.data.models.MarineAlert
+import com.jjswigut.eventide.data.models.MarineConditions
+import com.jjswigut.eventide.data.models.MarineObservation
+import com.jjswigut.eventide.data.models.WaveForecast
+import com.jjswigut.eventide.network.client.MarineServiceClient
+import com.jjswigut.eventide.network.responses.NwsAlertsResponse
+import com.jjswigut.eventide.network.responses.OpenMeteoMarineResponse
+import com.jjswigut.eventide.network.utils.Either
+import com.jjswigut.eventide.utils.GenericError
+import io.ktor.client.call.body
+import io.ktor.client.statement.bodyAsText
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.w3c.dom.Element
+import java.io.ByteArrayInputStream
+import java.util.Locale
+import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.roundToInt
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+class MarineServiceImpl(
+    private val client: MarineServiceClient,
+) : MarineService {
+    override suspend fun getMarineConditions(
+        stationId: String,
+        latitude: Double,
+        longitude: Double,
+    ): Either<MarineConditions, GenericError> = coroutineScope {
+        val coopsDeferred = async { fetchCoopsObservations(stationId) }
+        val alertsDeferred = async { fetchAlerts(latitude, longitude) }
+        val buoyDeferred = async { fetchNearestBuoy(latitude, longitude) }
+        val waveForecastDeferred = async { fetchOpenMeteoWaveForecast(latitude, longitude) }
+
+        Either.success(
+            MarineConditions(
+                observations = coopsDeferred.await(),
+                alerts = alertsDeferred.await(),
+                buoy = buoyDeferred.await(),
+                waveForecast = waveForecastDeferred.await(),
+            ),
+        )
+    }
+
+    private suspend fun fetchCoopsObservations(stationId: String): List<MarineObservation> = coroutineScope {
+        COOPS_PRODUCTS.map { product ->
+            async {
+                runCatching {
+                    val text = client.getCoopsLatestObservation(
+                        stationId = stationId,
+                        product = product.product,
+                    ).bodyAsText()
+                    product.toObservation(text)
+                }.getOrNull()
+            }
+        }.mapNotNull { it.await() }
+    }
+
+    private suspend fun fetchAlerts(
+        latitude: Double,
+        longitude: Double,
+    ): List<MarineAlert> {
+        return runCatching {
+            client.getActiveAlerts(latitude, longitude)
+                .body<NwsAlertsResponse>()
+                .features
+                .mapNotNull { feature ->
+                    val event = feature.properties.event?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                    MarineAlert(
+                        event = event,
+                        headline = feature.properties.headline?.takeIf { it.isNotBlank() } ?: event,
+                        severity = feature.properties.severity?.takeIf { it.isNotBlank() } ?: "Unknown",
+                    )
+                }
+                .take(MAX_ALERTS)
+        }.getOrDefault(emptyList())
+    }
+
+    private suspend fun fetchNearestBuoy(
+        latitude: Double,
+        longitude: Double,
+    ): BuoyConditions? {
+        return runCatching {
+            val activeStations = parseActiveStations(client.getNdbcActiveStations().bodyAsText())
+            val nearest = activeStations
+                .filter { it.hasMetData }
+                .map { station ->
+                    station to distanceMiles(latitude, longitude, station.latitude, station.longitude)
+                }
+                .filter { (_, distance) -> distance <= MAX_BUOY_DISTANCE_MILES }
+                .minByOrNull { (_, distance) -> distance }
+                ?: return null
+
+            val latestText = client.getNdbcRealtimeText(nearest.first.id).bodyAsText()
+            parseNdbcRealtimeText(
+                station = nearest.first,
+                distanceMiles = nearest.second,
+                text = latestText,
+            )
+        }.getOrNull()
+    }
+
+    private suspend fun fetchOpenMeteoWaveForecast(
+        latitude: Double,
+        longitude: Double,
+    ): WaveForecast? {
+        // Open-Meteo Marine is a no-key fallback for non-commercial use. UI attribution is required.
+        return runCatching {
+            val current = client.getOpenMeteoMarine(latitude, longitude)
+                .body<OpenMeteoMarineResponse>()
+                .current
+                ?: return null
+
+            WaveForecast(
+                waveHeight = current.waveHeight?.formatFeet(),
+                wavePeriod = current.wavePeriod?.formatSeconds(),
+                seaSurfaceTemperature = current.seaSurfaceTemperature?.formatFahrenheit(),
+            ).takeIf { it.waveHeight != null || it.wavePeriod != null || it.seaSurfaceTemperature != null }
+        }.getOrNull()
+    }
+
+    companion object {
+        private const val MAX_ALERTS = 3
+        private const val MAX_BUOY_DISTANCE_MILES = 150.0
+
+        private val json = Json {
+            ignoreUnknownKeys = true
+        }
+
+        private val COOPS_PRODUCTS = listOf(
+            CoopsProduct("water_temperature", "Water") { data -> data.stringValue("v")?.formatObservationValue("°F") },
+            CoopsProduct("air_temperature", "Air") { data -> data.stringValue("v")?.formatObservationValue("°F") },
+            CoopsProduct("wind", "CO-OPS wind") { value -> formatCoopsWind(value) },
+            CoopsProduct("air_pressure", "Pressure") { data -> data.stringValue("v")?.formatObservationValue("mb") },
+            CoopsProduct("visibility", "Visibility") { data -> data.stringValue("v")?.formatObservationValue("nmi") },
+            CoopsProduct("humidity", "Humidity") { data -> data.stringValue("v")?.formatObservationValue("%") },
+            CoopsProduct("salinity", "Salinity") { data -> data.stringValue("v")?.formatObservationValue("psu") },
+        )
+
+        internal fun parseActiveStations(xml: String): List<NdbcStation> {
+            val documentBuilderFactory = DocumentBuilderFactory.newInstance()
+            runCatching {
+                documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+                documentBuilderFactory.setFeature("http://xml.org/sax/features/external-general-entities", false)
+                documentBuilderFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+            }
+            val document = documentBuilderFactory
+                .newDocumentBuilder()
+                .parse(ByteArrayInputStream(xml.toByteArray()))
+            val stationNodes = document.getElementsByTagName("station")
+            return (0 until stationNodes.length).mapNotNull { index ->
+                val element = stationNodes.item(index) as? Element ?: return@mapNotNull null
+                NdbcStation(
+                    id = element.getAttribute("id").takeIf { it.isNotBlank() } ?: return@mapNotNull null,
+                    name = element.getAttribute("name").takeIf { it.isNotBlank() } ?: element.getAttribute("id"),
+                    latitude = element.getAttribute("lat").toDoubleOrNull() ?: return@mapNotNull null,
+                    longitude = element.getAttribute("lon").toDoubleOrNull() ?: return@mapNotNull null,
+                    hasMetData = element.getAttribute("met").equals("y", ignoreCase = true),
+                )
+            }
+        }
+
+        internal fun parseNdbcRealtimeText(
+            station: NdbcStation,
+            distanceMiles: Double,
+            text: String,
+        ): BuoyConditions? {
+            val lines = text.lineSequence()
+                .map { it.trim() }
+                .filter { it.isNotBlank() }
+                .toList()
+            val header = lines.firstOrNull { it.startsWith("#YY") || it.startsWith("#yr") }
+                ?.removePrefix("#")
+                ?.trim()
+                ?.split(Regex("\\s+"))
+                ?: return null
+            val latestData = lines.firstOrNull { !it.startsWith("#") }
+                ?.split(Regex("\\s+"))
+                ?: return null
+
+            fun value(column: String): Double? {
+                val index = header.indexOf(column)
+                if (index == -1) return null
+                return latestData.getOrNull(index)
+                    ?.toDoubleOrNull()
+                    ?.takeUnless { it.isMissingNdbcValue(column) }
+            }
+
+            val windSpeed = value("WSPD")
+            val gust = value("GST")
+            val windDirection = value("WDIR")
+            val wind = windSpeed?.let {
+                buildString {
+                    append("${windDirection?.roundToInt()?.let { direction -> "$direction° " } ?: ""}${it.metersPerSecondToKnots()}")
+                    gust?.let { gustSpeed -> append(" gust ${gustSpeed.metersPerSecondToKnots()}") }
+                }
+            }
+
+            return BuoyConditions(
+                stationId = station.id,
+                stationName = station.name,
+                distanceMiles = distanceMiles,
+                wind = wind,
+                waveHeight = value("WVHT")?.metersToFeet()?.formatFeet(),
+                wavePeriod = value("DPD")?.formatSeconds(),
+                waterTemperature = value("WTMP")?.celsiusToFahrenheit()?.formatFahrenheit(),
+                pressure = value("PRES")?.formatPressure(),
+            ).takeIf {
+                it.wind != null ||
+                    it.waveHeight != null ||
+                    it.wavePeriod != null ||
+                    it.waterTemperature != null ||
+                    it.pressure != null
+            }
+        }
+
+        private fun CoopsProduct.toObservation(text: String): MarineObservation? {
+            val data = runCatching {
+                json.parseToJsonElement(text)
+                    .jsonObject["data"]
+                    ?.jsonArray
+                    ?.firstOrNull()
+                    ?.jsonObject
+            }.getOrNull() ?: return null
+            val value = formatter(data) ?: return null
+            return MarineObservation(label = label, value = value)
+        }
+
+        private fun formatCoopsWind(data: JsonObject): String? {
+            val speed = data.stringValue("s") ?: return null
+            val direction = data.stringValue("dr") ?: data.stringValue("d")?.let { "$it°" }
+            val gust = data.stringValue("g")
+            return buildString {
+                direction?.let {
+                    append(it)
+                    append(" ")
+                }
+                append(speed.formatObservationValue("kt"))
+                gust?.let {
+                    append(" gust ")
+                    append(it.formatObservationValue("kt"))
+                }
+            }
+        }
+
+        private fun JsonObject.stringValue(key: String): String? {
+            val primitive = this[key] as? JsonPrimitive ?: return null
+            return primitive.jsonPrimitive.content.takeIf { it.isNotBlank() && !it.equals("null", ignoreCase = true) }
+        }
+
+        private fun String.formatObservationValue(unit: String): String? {
+            val value = toDoubleOrNull() ?: return null
+            return "${value.formatOneDecimal()}$unit"
+        }
+
+        private fun distanceMiles(
+            startLatitude: Double,
+            startLongitude: Double,
+            endLatitude: Double,
+            endLongitude: Double,
+        ): Double {
+            val earthRadiusMiles = 3958.8
+            val dLat = Math.toRadians(endLatitude - startLatitude)
+            val dLng = Math.toRadians(endLongitude - startLongitude)
+            val a = sin(dLat / 2) * sin(dLat / 2) +
+                cos(Math.toRadians(startLatitude)) * cos(Math.toRadians(endLatitude)) *
+                sin(dLng / 2) * sin(dLng / 2)
+            val c = 2 * atan2(sqrt(a), sqrt(1 - a))
+            return earthRadiusMiles * c
+        }
+
+        private fun Double.metersToFeet(): Double = this * 3.28084
+
+        private fun Double.metersPerSecondToKnots(): String = "${(this * 1.94384).formatOneDecimal()}kt"
+
+        private fun Double.celsiusToFahrenheit(): Double = (this * 9 / 5) + 32
+
+        private fun Double.formatFeet(): String = "${formatOneDecimal()}ft"
+
+        private fun Double.formatSeconds(): String = "${formatOneDecimal()}s"
+
+        private fun Double.formatFahrenheit(): String = "${formatOneDecimal()}°F"
+
+        private fun Double.formatPressure(): String = "${formatOneDecimal()}hPa"
+
+        private fun Double.formatOneDecimal(): String = String.format(Locale.US, "%.1f", this)
+
+        private fun Double.isMissingNdbcValue(column: String): Boolean {
+            return when (column) {
+                "WDIR", "MWD" -> this >= 999.0
+                "PRES" -> this >= 9999.0
+                else -> this >= 99.0 || this <= -99.0
+            }
+        }
+    }
+}
+
+internal data class NdbcStation(
+    val id: String,
+    val name: String,
+    val latitude: Double,
+    val longitude: Double,
+    val hasMetData: Boolean,
+)
+
+private data class CoopsProduct(
+    val product: String,
+    val label: String,
+    val formatter: (JsonObject) -> String?,
+)

--- a/app/src/main/kotlin/com/jjswigut/eventide/repository/NoaaRepository.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/repository/NoaaRepository.kt
@@ -1,6 +1,7 @@
 package com.jjswigut.eventide.repository
 
 import com.google.android.gms.maps.model.LatLngBounds
+import com.jjswigut.eventide.data.models.MarineConditions
 import com.jjswigut.eventide.data.models.Station
 import com.jjswigut.eventide.data.models.TideDay
 import com.jjswigut.eventide.network.utils.Either
@@ -16,6 +17,8 @@ interface NoaaRepository {
     suspend fun getTidesForStation(stationID: String): Either<List<TideDay>, GenericError>
 
     suspend fun getTidesWithWeather(stationID: String): Either<List<TideDay>, GenericError>
+
+    suspend fun getMarineConditionsForStation(stationID: String): Either<MarineConditions, GenericError>
 
     suspend fun getTidesImmediately(
         stationID: String,

--- a/app/src/main/kotlin/com/jjswigut/eventide/repository/NoaaRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/repository/NoaaRepositoryImpl.kt
@@ -3,11 +3,13 @@ package com.jjswigut.eventide.repository
 import com.google.android.gms.maps.model.LatLngBounds
 import com.jjswigut.eventide.StationsDb
 import com.jjswigut.eventide.astronomy.withSunMoonData
+import com.jjswigut.eventide.data.models.MarineConditions
 import com.jjswigut.eventide.data.models.Station
 import com.jjswigut.eventide.data.models.TideDay
 import com.jjswigut.eventide.data.models.Weather
 import com.jjswigut.eventide.db.toModel
 import com.jjswigut.eventide.network.responses.StationsResponse.StationDto
+import com.jjswigut.eventide.network.service.MarineService
 import com.jjswigut.eventide.network.service.NoaaService
 import com.jjswigut.eventide.network.service.WeatherService
 import com.jjswigut.eventide.network.utils.Either
@@ -21,6 +23,7 @@ import kotlinx.coroutines.launch
 class NoaaRepositoryImpl(
     private val noaaService: NoaaService,
     private val weatherService: WeatherService,
+    private val marineService: MarineService,
     private val stationsDb: StationsDb,
 ) : NoaaRepository {
 
@@ -73,6 +76,15 @@ class NoaaRepositoryImpl(
                 }
             }
         }
+
+    override suspend fun getMarineConditionsForStation(stationID: String): Either<MarineConditions, GenericError> {
+        val station = getStationById(stationID) ?: return Either.success(MarineConditions())
+        return marineService.getMarineConditions(
+            stationId = stationID,
+            latitude = station.latLng.latitude,
+            longitude = station.latLng.longitude,
+        )
+    }
 
     override suspend fun getTidesImmediately(
         stationID: String,

--- a/app/src/main/kotlin/com/jjswigut/eventide/repository/RepositoryModule.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/repository/RepositoryModule.kt
@@ -7,6 +7,7 @@ val repositoryModule = module {
         NoaaRepositoryImpl(
             noaaService = get(),
             weatherService = get(),
+            marineService = get(),
             stationsDb = get(),
         )
     }

--- a/app/src/test/java/com/jjswigut/eventide/network/service/MarineServiceImplTest.kt
+++ b/app/src/test/java/com/jjswigut/eventide/network/service/MarineServiceImplTest.kt
@@ -1,0 +1,80 @@
+package com.jjswigut.eventide.network.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class MarineServiceImplTest {
+    @Test
+    fun `parseActiveStations reads station metadata`() {
+        val xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <stations>
+              <station id="44060" lat="41.263" lon="-72.067" name="Eastern Long Island Sound" met="y"/>
+              <station id="skip" lat="" lon="-72.067" name="Broken" met="y"/>
+            </stations>
+        """.trimIndent()
+
+        val stations = MarineServiceImpl.parseActiveStations(xml)
+
+        assertEquals(1, stations.size)
+        assertEquals("44060", stations.first().id)
+        assertEquals("Eastern Long Island Sound", stations.first().name)
+        assertEquals(41.263, stations.first().latitude, 0.0)
+        assertEquals(-72.067, stations.first().longitude, 0.0)
+        assertEquals(true, stations.first().hasMetData)
+    }
+
+    @Test
+    fun `parseNdbcRealtimeText maps latest conditions and ignores sentinels`() {
+        val station = NdbcStation(
+            id = "44060",
+            name = "Eastern Long Island Sound",
+            latitude = 41.263,
+            longitude = -72.067,
+            hasMetData = true,
+        )
+        val text = """
+            #YY  MM DD hh mm WDIR WSPD GST WVHT DPD APD MWD PRES ATMP WTMP DEWP VIS PTDY TIDE
+            #yr  mo dy hr mn degT m/s  m/s m    sec sec degT hPa  degC degC degC nmi hPa  ft
+            2026 07 07 18 50 220  5.0  7.0 1.2  8   7.5 230  1013.4 19.0 18.1 17.1 99.0 1.2 99.0
+        """.trimIndent()
+
+        val buoy = MarineServiceImpl.parseNdbcRealtimeText(
+            station = station,
+            distanceMiles = 12.4,
+            text = text,
+        )
+
+        requireNotNull(buoy)
+        assertEquals("44060", buoy.stationId)
+        assertEquals("220° 9.7kt gust 13.6kt", buoy.wind)
+        assertEquals("3.9ft", buoy.waveHeight)
+        assertEquals("8.0s", buoy.wavePeriod)
+        assertEquals("64.6°F", buoy.waterTemperature)
+        assertEquals("1013.4hPa", buoy.pressure)
+    }
+
+    @Test
+    fun `parseNdbcRealtimeText returns null when all values are missing`() {
+        val station = NdbcStation(
+            id = "44060",
+            name = "Eastern Long Island Sound",
+            latitude = 41.263,
+            longitude = -72.067,
+            hasMetData = true,
+        )
+        val text = """
+            #YY  MM DD hh mm WDIR WSPD GST WVHT DPD PRES WTMP
+            2026 07 07 18 50 999  99.0 99.0 99.0 99 9999.0 99.0
+        """.trimIndent()
+
+        val buoy = MarineServiceImpl.parseNdbcRealtimeText(
+            station = station,
+            distanceMiles = 12.4,
+            text = text,
+        )
+
+        assertNull(buoy)
+    }
+}

--- a/docs/marine-weather-sources.md
+++ b/docs/marine-weather-sources.md
@@ -1,0 +1,15 @@
+# Marine Weather Sources
+
+Eventide uses no-key/free marine and weather data sources for selected tide stations.
+
+- NOAA CO-OPS Data API: latest station observations for supported products such as wind, air and water temperature, pressure, visibility, humidity, and salinity.
+- National Weather Service API: active alerts for the selected station point. Requests must keep an identifying `User-Agent`.
+- National Data Buoy Center: active station metadata and realtime HTTPS flat files for the nearest buoy within the app's configured search radius.
+- NOAA nowCOAST/NWS map services: radar, weather, and GOES satellite/cloud imagery layers.
+- Open-Meteo Marine: no-key non-commercial fallback for modeled wave height, wave period, and sea-surface temperature. Open-Meteo and its upstream model providers require attribution in user-visible output.
+
+Follow-up items:
+
+- CO-OPS currents require station-specific bin handling; do not request them until the app can resolve or present supported bins.
+- Additional nowCOAST layers such as marine warnings, watches, surface wind analysis, and sea-surface temperature analysis should be added only after validating stable service/layer names and mobile map readability.
+- NDBC realtime parsing currently uses standard meteorological flat files. Spectral wave summary files can provide richer wave data where available.


### PR DESCRIPTION
## Summary
- Add station-level marine conditions for selected tide stations using NOAA CO-OPS latest observations, NWS active alerts, nearest NDBC realtime buoy conditions, and Open-Meteo Marine wave fallback.
- Render a compact Marine conditions panel in the station tide detail flow with graceful unavailable behavior.
- Add a nowCOAST GOES satellite/cloud map overlay alongside existing radar/weather overlays.
- Document source terms, attribution, and follow-up items in docs/marine-weather-sources.md.

## Implemented data sources
- NOAA CO-OPS Data API latest products: water_temperature, air_temperature, wind, air_pressure, visibility, humidity, salinity when each station supports them.
- NWS API active alerts via /alerts/active?point={lat},{lon}, preserving the identifying User-Agent.
- NDBC active station metadata plus nearest realtime standard meteorological flat file parsing for wind, wave height/period, water temperature, and pressure.
- Open-Meteo Marine current wave fallback for wave height, wave period, and sea-surface temperature with visible attribution.
- nowCOAST GOES satellite/cloud WMS layer.

## Deferred intentionally
- CO-OPS currents: require station/bin-specific handling before this can be requested honestly.
- Additional nowCOAST marine warning/watch, sea-surface temperature, and surface wind analysis layers: documented for follow-up after validating stable layer names and mobile readability.
- NDBC spectral wave summary files: standard met flat files are parsed in this pass; richer spectral files can be layered later.

## Verification
- git status --short --branch before setup: ## HEAD (no branch)
- git status --short --branch before push: ## swiggy/marine-weather-sources...origin/develop [ahead 1]
- source tools/eventide_env.sh && ./gradlew testDebugUnitTest --tests com.jjswigut.eventide.network.service.MarineServiceImplTest: passed
- tools/eventide_verify.sh: passed
- EVENTIDE_FORCE_EMULATOR=1 EVENTIDE_STOP_EMULATOR=1 tools/eventide_smoke.sh: passed
- Smoke target: emulator-5554
- Screenshot: /Users/swig/.codex/worktrees/6e85/Eventide/build/smoke/eventide-smoke-20260707-150940.png