### PR TITLE
Polish Eventide interaction motion

### DIFF
--- a/app/src/main/kotlin/com/jjswigut/eventide/map/components/FavoritesPanel.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/map/components/FavoritesPanel.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -32,6 +34,7 @@ import com.jjswigut.eventide.R
 import com.jjswigut.eventide.data.models.Station
 import com.jjswigut.eventide.data.models.TideAlertFilter
 import com.jjswigut.eventide.data.models.TideAlertPreference
+import com.jjswigut.eventide.ui.components.rememberEventideEntranceProgress
 import com.jjswigut.eventide.ui.theme.BackgroundDark
 import com.jjswigut.eventide.ui.theme.LightText
 import com.jjswigut.eventide.ui.theme.Primary
@@ -46,6 +49,7 @@ private object FavoritesPanelDesign {
     val rowSpacing = 6.dp
     val maxHeight = 340.dp
     val iconSize = 24.dp
+    val panelEntranceOffset = 18.dp
 }
 
 @Composable
@@ -61,6 +65,8 @@ fun FavoritesPanel(
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val density = LocalDensity.current
+    val entranceProgress = rememberEventideEntranceProgress("favorites")
     val gradientBrush = Brush.verticalGradient(
         colors = listOf(
             BackgroundDark.copy(alpha = 0.96f),
@@ -73,6 +79,12 @@ fun FavoritesPanel(
             .padding(16.dp)
             .fillMaxWidth()
             .heightIn(max = FavoritesPanelDesign.maxHeight)
+            .graphicsLayer {
+                alpha = entranceProgress
+                translationY = with(density) {
+                    FavoritesPanelDesign.panelEntranceOffset.toPx()
+                } * (1f - entranceProgress)
+            }
             .background(
                 brush = gradientBrush,
                 shape = RoundedCornerShape(FavoritesPanelDesign.cornerRadius),
@@ -256,6 +268,7 @@ private fun SelectableChip(
     Box(
         modifier = Modifier
             .widthIn(min = 52.dp)
+            .heightIn(min = 48.dp)
             .clip(RoundedCornerShape(FavoritesPanelDesign.cornerRadius))
             .clickable(onClick = onClick)
             .background(
@@ -285,7 +298,7 @@ private val LEAD_TIME_OPTIONS = listOf(30, 60, 120)
 private fun ClosePanelButton(onClick: () -> Unit) {
     Box(
         modifier = Modifier
-            .size(36.dp)
+            .size(48.dp)
             .clip(RoundedCornerShape(FavoritesPanelDesign.cornerRadius))
             .clickable(onClick = onClick)
             .background(PrimaryLight.copy(alpha = 0.22f)),

--- a/app/src/main/kotlin/com/jjswigut/eventide/map/components/SettingsPanel.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/map/components/SettingsPanel.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -31,6 +33,7 @@ import com.jjswigut.eventide.settings.AppSettings
 import com.jjswigut.eventide.settings.TempUnit
 import com.jjswigut.eventide.settings.TideUnit
 import com.jjswigut.eventide.settings.TimeFormat
+import com.jjswigut.eventide.ui.components.rememberEventideEntranceProgress
 import com.jjswigut.eventide.ui.theme.BackgroundDark
 import com.jjswigut.eventide.ui.theme.LightText
 import com.jjswigut.eventide.ui.theme.PrimaryDark
@@ -42,6 +45,7 @@ private object SettingsPanelDesign {
     val panelPadding = 16.dp
     val maxHeight = 420.dp
     val iconSize = 24.dp
+    val panelEntranceOffset = 18.dp
 }
 
 @Composable
@@ -55,6 +59,8 @@ fun SettingsPanel(
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val density = LocalDensity.current
+    val entranceProgress = rememberEventideEntranceProgress("settings")
     val gradientBrush = Brush.verticalGradient(
         colors = listOf(
             BackgroundDark.copy(alpha = 0.96f),
@@ -67,6 +73,12 @@ fun SettingsPanel(
             .padding(16.dp)
             .fillMaxWidth()
             .heightIn(max = SettingsPanelDesign.maxHeight)
+            .graphicsLayer {
+                alpha = entranceProgress
+                translationY = with(density) {
+                    SettingsPanelDesign.panelEntranceOffset.toPx()
+                } * (1f - entranceProgress)
+            }
             .background(
                 brush = gradientBrush,
                 shape = RoundedCornerShape(SettingsPanelDesign.cornerRadius),
@@ -186,6 +198,7 @@ private fun SelectableChip(
     Box(
         modifier = Modifier
             .widthIn(min = 64.dp)
+            .heightIn(min = 48.dp)
             .clip(RoundedCornerShape(SettingsPanelDesign.cornerRadius))
             .clickable(onClick = onClick)
             .background(
@@ -213,7 +226,7 @@ private fun SelectableChip(
 private fun ClosePanelButton(onClick: () -> Unit) {
     Box(
         modifier = Modifier
-            .size(36.dp)
+            .size(48.dp)
             .clip(RoundedCornerShape(SettingsPanelDesign.cornerRadius))
             .clickable(onClick = onClick)
             .background(PrimaryLight.copy(alpha = 0.22f)),

--- a/app/src/main/kotlin/com/jjswigut/eventide/map/components/StationInfoRow.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/map/components/StationInfoRow.kt
@@ -1,5 +1,7 @@
 package com.jjswigut.eventide.map.components
 
+import android.view.HapticFeedbackConstants
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -18,14 +20,22 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -37,8 +47,11 @@ import com.jjswigut.eventide.map.MapAction
 import com.jjswigut.eventide.settings.AppSettings
 import com.jjswigut.eventide.ui.components.Action
 import com.jjswigut.eventide.ui.components.BodyText
+import com.jjswigut.eventide.ui.components.EventideMotion
 import com.jjswigut.eventide.ui.components.SectionTitleText
 import com.jjswigut.eventide.ui.components.ShimmerLoading
+import com.jjswigut.eventide.ui.components.rememberEventideEntranceProgress
+import com.jjswigut.eventide.ui.components.rememberEventideMotionEnabled
 import com.jjswigut.eventide.ui.theme.BackgroundDark
 import com.jjswigut.eventide.ui.theme.Primary
 import com.jjswigut.eventide.ui.theme.PrimaryDark
@@ -74,7 +87,17 @@ fun StationInfoRow(
     settings: AppSettings,
     actionHandler: (Action) -> Unit,
 ) {
-    Column(modifier = modifier) {
+    val density = LocalDensity.current
+    val entranceProgress = rememberEventideEntranceProgress(station?.id ?: list.firstOrNull()?.date)
+
+    Column(
+        modifier = modifier.graphicsLayer {
+            alpha = entranceProgress
+            scaleX = DETAIL_MIN_SCALE + ((1f - DETAIL_MIN_SCALE) * entranceProgress)
+            scaleY = DETAIL_MIN_SCALE + ((1f - DETAIL_MIN_SCALE) * entranceProgress)
+            translationY = with(density) { DETAIL_ENTRANCE_OFFSET.toPx() } * (1f - entranceProgress)
+        },
+    ) {
         Row(
             modifier = Modifier.align(Alignment.End),
         ) {
@@ -258,9 +281,35 @@ private fun FavoriteButton(
     isFavorite: Boolean,
     onClick: () -> Unit,
 ) {
+    val motionEnabled = rememberEventideMotionEnabled()
+    val pulseScale = remember { Animatable(1f) }
+    var hasObservedState by remember { mutableStateOf(false) }
+
+    LaunchedEffect(isFavorite, motionEnabled) {
+        if (!hasObservedState) {
+            hasObservedState = true
+            pulseScale.snapTo(1f)
+            return@LaunchedEffect
+        }
+
+        if (!motionEnabled) {
+            pulseScale.snapTo(1f)
+            return@LaunchedEffect
+        }
+
+        pulseScale.snapTo(0.94f)
+        pulseScale.animateTo(1.12f, EventideMotion.confirmationSpring)
+        pulseScale.animateTo(1f, EventideMotion.directSpring)
+    }
+
     HeaderButton(
+        modifier = Modifier.graphicsLayer {
+            scaleX = pulseScale.value
+            scaleY = pulseScale.value
+        },
         iconRes = if (isFavorite) R.drawable.star_filled else R.drawable.star_outline,
         contentDescription = if (isFavorite) "Remove favorite" else "Save favorite",
+        hapticFeedback = true,
         onClick = onClick,
     )
 }
@@ -283,8 +332,10 @@ private fun HeaderButton(
     modifier: Modifier = Modifier,
     iconRes: Int,
     contentDescription: String,
+    hapticFeedback: Boolean = false,
     onClick: () -> Unit,
 ) {
+    val view = LocalView.current
     val gradientBrush = Brush.radialGradient(
         colors = listOf(
             PrimaryLight,
@@ -311,7 +362,12 @@ private fun HeaderButton(
                 shape = RoundedCornerShape(StationInfoDesign.closeButtonCornerRadius),
             )
             .clip(shape = RoundedCornerShape(StationInfoDesign.closeButtonCornerRadius))
-            .clickable(onClick = onClick),
+            .clickable(role = Role.Button) {
+                if (hapticFeedback) {
+                    view.performHapticFeedback(HapticFeedbackConstants.CONTEXT_CLICK)
+                }
+                onClick()
+            },
     ) {
         Image(
             painter = painterResource(id = iconRes),
@@ -320,6 +376,9 @@ private fun HeaderButton(
         )
     }
 }
+
+private val DETAIL_ENTRANCE_OFFSET = 22.dp
+private const val DETAIL_MIN_SCALE = 0.965f
 
 @Composable
 private fun TideCardList(

--- a/app/src/main/kotlin/com/jjswigut/eventide/map/components/TideGraph.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/map/components/TideGraph.kt
@@ -1,8 +1,10 @@
 package com.jjswigut.eventide.map.components
 
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -17,6 +19,8 @@ import com.jjswigut.eventide.data.models.TideValue
 import com.jjswigut.eventide.settings.AppSettings
 import com.jjswigut.eventide.settings.displayHeight
 import com.jjswigut.eventide.settings.displayTime
+import com.jjswigut.eventide.ui.components.EventideMotion
+import com.jjswigut.eventide.ui.components.rememberEventideMotionEnabled
 import com.jjswigut.eventide.ui.theme.BackgroundDark
 import com.jjswigut.eventide.ui.theme.Primary
 import com.jjswigut.eventide.ui.theme.PrimaryDark
@@ -27,6 +31,7 @@ import java.time.LocalDateTime
 import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.max
+import kotlin.math.roundToInt
 
 @Composable
 fun TideGraph(
@@ -51,10 +56,23 @@ fun TideGraph(
             }
         }.sortedBy { it.dateTime }
     }
+    val motionEnabled = rememberEventideMotionEnabled()
+    val revealProgress = remember { Animatable(if (motionEnabled) 0f else 1f) }
+
+    LaunchedEffect(points, motionEnabled) {
+        if (!motionEnabled) {
+            revealProgress.snapTo(1f)
+            return@LaunchedEffect
+        }
+
+        revealProgress.snapTo(0f)
+        revealProgress.animateTo(1f, EventideMotion.entranceSpring)
+    }
 
     Canvas(modifier = modifier.fillMaxSize()) {
         if (points.size < MIN_POINT_COUNT) return@Canvas
 
+        val reveal = revealProgress.value.coerceIn(0f, 1f)
         val leftPadding = 32.dp.toPx()
         val rightPadding = 12.dp.toPx()
         val topPadding = 14.dp.toPx()
@@ -97,38 +115,66 @@ fun TideGraph(
 
         val curvePath = Path()
         val samples = buildCurveSamples(points)
-        samples.forEachIndexed { index, sample ->
+        val visibleSamples = samples.take(visibleTideSampleCount(samples.size, reveal))
+        val baselineY = topPadding + graphHeight
+        val waterPath = Path()
+
+        visibleSamples.firstOrNull()?.let { firstSample ->
+            val firstPoint = Offset(xFor(firstSample.dateTime), yFor(firstSample.heightFeet))
+            waterPath.moveTo(firstPoint.x, baselineY)
+            waterPath.lineTo(firstPoint.x, firstPoint.y)
+        }
+
+        visibleSamples.forEachIndexed { index, sample ->
             val point = Offset(xFor(sample.dateTime), yFor(sample.heightFeet))
             if (index == 0) {
                 curvePath.moveTo(point.x, point.y)
             } else {
                 curvePath.lineTo(point.x, point.y)
             }
+            if (index > 0) {
+                waterPath.lineTo(point.x, point.y)
+            }
         }
-        drawPath(
-            path = curvePath,
-            color = PrimaryDark,
-            style = Stroke(width = CURVE_WIDTH, cap = StrokeCap.Round),
-        )
+        visibleSamples.lastOrNull()?.let { lastSample ->
+            waterPath.lineTo(xFor(lastSample.dateTime), baselineY)
+            waterPath.close()
+            drawPath(
+                path = waterPath,
+                color = PrimaryDark.copy(alpha = WATER_FILL_ALPHA * reveal),
+            )
+        }
+        if (visibleSamples.size >= MIN_POINT_COUNT) {
+            drawPath(
+                path = curvePath,
+                color = PrimaryDark,
+                style = Stroke(width = CURVE_WIDTH, cap = StrokeCap.Round),
+            )
+        }
 
+        val visibleEndX = visibleSamples.lastOrNull()?.let { xFor(it.dateTime) } ?: leftPadding
+        val labelAlpha = ((reveal - LABEL_REVEAL_START) / (1f - LABEL_REVEAL_START)).coerceIn(0f, 1f)
         points.forEach { point ->
             val center = Offset(xFor(point.dateTime), yFor(point.heightFeet))
-            drawCircle(
-                color = if (point.tideValue == TideValue.High) Primary else BackgroundDark,
-                radius = EXTREME_RADIUS,
-                center = center,
-            )
-            drawLabel(
-                text = "${point.timeLabel}\n${point.heightLabel}",
-                x = center.x,
-                y = if (point.tideValue == TideValue.High) {
-                    center.y - LABEL_VERTICAL_OFFSET
-                } else {
-                    center.y + LABEL_VERTICAL_OFFSET
-                },
-                color = BackgroundDark,
-                alignCenter = true,
-            )
+            if (center.x <= visibleEndX + POINT_VISIBILITY_PADDING && labelAlpha > 0f) {
+                val pointColor = if (point.tideValue == TideValue.High) Primary else BackgroundDark
+                drawCircle(
+                    color = pointColor.copy(alpha = labelAlpha),
+                    radius = EXTREME_RADIUS,
+                    center = center,
+                )
+                drawLabel(
+                    text = "${point.timeLabel}\n${point.heightLabel}",
+                    x = center.x,
+                    y = if (point.tideValue == TideValue.High) {
+                        center.y - LABEL_VERTICAL_OFFSET
+                    } else {
+                        center.y + LABEL_VERTICAL_OFFSET
+                    },
+                    color = BackgroundDark.copy(alpha = labelAlpha),
+                    alignCenter = true,
+                )
+            }
         }
 
         val now = LocalDateTime.now()
@@ -188,6 +234,17 @@ private fun buildCurveSamples(points: List<TideGraphPoint>): List<TideGraphPoint
             )
         }
     }.distinctBy { it.dateTime }
+}
+
+internal fun visibleTideSampleCount(totalSamples: Int, progress: Float): Int {
+    if (totalSamples <= 0) return 0
+    if (totalSamples == 1) return 1
+
+    val clampedProgress = progress.coerceIn(0f, 1f)
+    if (clampedProgress >= 1f) return totalSamples
+
+    val revealedSamples = 2 + ((totalSamples - 2) * clampedProgress).roundToInt()
+    return revealedSamples.coerceIn(2, totalSamples)
 }
 
 private fun interpolateHeight(points: List<TideGraphPoint>, dateTime: LocalDateTime): Double {
@@ -266,4 +323,7 @@ private const val NOW_LABEL_OFFSET = 12f
 private const val LABEL_TEXT_SIZE = 24f
 private const val LABEL_LINE_HEIGHT = 24f
 private const val LABEL_ALPHA = 0.78f
+private const val LABEL_REVEAL_START = 0.68f
+private const val WATER_FILL_ALPHA = 0.16f
+private const val POINT_VISIBILITY_PADDING = 1f
 private const val COLOR_COMPONENT_MAX = 255

--- a/app/src/main/kotlin/com/jjswigut/eventide/ui/components/EventideMotion.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/ui/components/EventideMotion.kt
@@ -1,0 +1,48 @@
+package com.jjswigut.eventide.ui.components
+
+import android.animation.ValueAnimator
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.SpringSpec
+import androidx.compose.animation.core.spring
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+
+object EventideMotion {
+    val entranceSpring: SpringSpec<Float> = spring(
+        dampingRatio = Spring.DampingRatioNoBouncy,
+        stiffness = Spring.StiffnessMedium,
+    )
+    val directSpring: SpringSpec<Float> = spring(
+        dampingRatio = Spring.DampingRatioNoBouncy,
+        stiffness = Spring.StiffnessHigh,
+    )
+    val confirmationSpring: SpringSpec<Float> = spring(
+        dampingRatio = Spring.DampingRatioMediumBouncy,
+        stiffness = Spring.StiffnessHigh,
+    )
+}
+
+@Composable
+fun rememberEventideMotionEnabled(): Boolean {
+    return ValueAnimator.areAnimatorsEnabled()
+}
+
+@Composable
+fun rememberEventideEntranceProgress(key: Any?): Float {
+    val motionEnabled = rememberEventideMotionEnabled()
+    val progress = remember { Animatable(if (motionEnabled) 0f else 1f) }
+
+    LaunchedEffect(key, motionEnabled) {
+        if (!motionEnabled) {
+            progress.snapTo(1f)
+            return@LaunchedEffect
+        }
+
+        progress.snapTo(0f)
+        progress.animateTo(1f, EventideMotion.entranceSpring)
+    }
+
+    return progress.value
+}

--- a/app/src/main/kotlin/com/jjswigut/eventide/ui/components/MenuButton.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/ui/components/MenuButton.kt
@@ -2,8 +2,10 @@ package com.jjswigut.eventide.ui.components
 
 import androidx.annotation.DrawableRes
 import androidx.compose.animation.Crossfade
-import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.background
@@ -23,6 +25,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.jjswigut.eventide.R
@@ -42,6 +48,7 @@ fun MenuButton(
     selectedActions: Set<Action> = emptySet(),
     actionHandler: (Action) -> Unit,
 ) {
+    val motionEnabled = rememberEventideMotionEnabled()
     val mainButtonSize = 58.dp
     val menuButtonSize = 48.dp
     val spacing = 10.dp
@@ -58,22 +65,32 @@ fun MenuButton(
         val baseOffset = mainButtonSize + spacing
 
         menuButtons.forEachIndexed { index, menuButton ->
-            val progress = expansionTransition.animateFloat(
+            val animatedProgress = expansionTransition.animateFloat(
                 transitionSpec = {
-                    tween(
-                        durationMillis = if (targetState) 220 else 140,
-                        delayMillis = if (targetState) index * 30 else 0,
-                        easing = FastOutSlowInEasing,
+                    spring(
+                        dampingRatio = Spring.DampingRatioNoBouncy,
+                        stiffness = if (targetState) {
+                            Spring.StiffnessMediumLow
+                        } else {
+                            Spring.StiffnessMedium
+                        },
                     )
                 },
                 label = "Menu option $index progress",
             ) { isExpanded ->
                 if (isExpanded) 1f else 0f
             }
+            val progress = if (motionEnabled) {
+                animatedProgress.value
+            } else if (expanded) {
+                1f
+            } else {
+                0f
+            }
             val angle = menuButtonAngle(index, angleOffset)
-            val scale = 0.8f + (0.2f * progress.value)
+            val scale = 0.8f + (0.2f * progress)
 
-            if (expanded || progress.value > 0.01f) {
+            if (expanded || progress > 0.01f) {
                 OutsideButton(
                     menuButton = menuButton,
                     enabled = expanded,
@@ -81,11 +98,11 @@ fun MenuButton(
                     size = menuButtonSize,
                     modifier = Modifier
                         .offset(
-                            x = cos(angle) * baseOffset * progress.value,
-                            y = sin(angle) * baseOffset * progress.value,
+                            x = cos(angle) * baseOffset * progress,
+                            y = sin(angle) * baseOffset * progress,
                         )
                         .graphicsLayer {
-                            alpha = progress.value
+                            alpha = progress
                             scaleX = scale
                             scaleY = scale
                         },
@@ -100,17 +117,17 @@ fun MenuButton(
                 .shadow(10.dp, CircleShape)
                 .background(shape = CircleShape, color = PrimaryDark)
                 .clip(CircleShape)
-                .clickable { actionHandler(centerButton.action) },
+                .clickable(role = Role.Button) { actionHandler(centerButton.action) },
             contentAlignment = Alignment.Center,
         ) {
             Crossfade(
                 targetState = expanded,
-                animationSpec = tween(durationMillis = 120),
+                animationSpec = tween(durationMillis = if (motionEnabled) 120 else 0),
                 label = "Menu icon",
             ) { isExpanded ->
                 Icon(
                     painter = painterResource(if (isExpanded) R.drawable.close_icon else centerButton.iconRes),
-                    contentDescription = null,
+                    contentDescription = if (isExpanded) "Close menu" else "Open menu",
                     tint = LightText,
                 )
             }
@@ -140,16 +157,32 @@ private fun OutsideButton(
     size: Dp,
     onClick: (Action) -> Unit,
 ) {
-    val backgroundColor = if (selected) SecondaryLight else PrimaryDark
-    val iconColor = if (selected) BackgroundDark else LightText
+    val motionEnabled = rememberEventideMotionEnabled()
+    val backgroundColor = animateColorAsState(
+        targetValue = if (selected) SecondaryLight else PrimaryDark,
+        animationSpec = tween(durationMillis = if (motionEnabled) 140 else 0),
+        label = "${menuButton.text} background",
+    )
+    val iconColor = animateColorAsState(
+        targetValue = if (selected) BackgroundDark else LightText,
+        animationSpec = tween(durationMillis = if (motionEnabled) 140 else 0),
+        label = "${menuButton.text} icon",
+    )
 
     Column(
         modifier = modifier
             .size(size)
             .shadow(8.dp, CircleShape)
-            .background(shape = CircleShape, color = backgroundColor)
+            .background(shape = CircleShape, color = backgroundColor.value)
             .clip(CircleShape)
-            .clickable(enabled = enabled) {
+            .semantics {
+                contentDescription = menuButton.text
+                stateDescription = if (selected) "Selected" else "Not selected"
+            }
+            .clickable(
+                enabled = enabled,
+                role = Role.Button,
+            ) {
                 onClick(menuButton.action)
             },
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -158,7 +191,7 @@ private fun OutsideButton(
         Icon(
             painter = painterResource(id = menuButton.iconRes),
             contentDescription = null,
-            tint = iconColor,
+            tint = iconColor.value,
         )
     }
 }

--- a/app/src/main/kotlin/com/jjswigut/eventide/ui/components/ShimmerLoading.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/ui/components/ShimmerLoading.kt
@@ -26,31 +26,41 @@ import androidx.compose.ui.unit.dp
 fun ShimmerLoading(
     modifier: Modifier = Modifier,
 ) {
-    val infiniteTransition = rememberInfiniteTransition(label = "shimmer")
-    val shimmerTranslate by infiniteTransition.animateFloat(
-        initialValue = 0f,
-        targetValue = 1000f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(
-                durationMillis = 1200,
-                easing = LinearEasing,
+    val motionEnabled = rememberEventideMotionEnabled()
+    val brush = if (motionEnabled) {
+        val infiniteTransition = rememberInfiniteTransition(label = "shimmer")
+        val shimmerTranslate by infiniteTransition.animateFloat(
+            initialValue = 0f,
+            targetValue = 1000f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(
+                    durationMillis = 1200,
+                    easing = LinearEasing,
+                ),
+                repeatMode = RepeatMode.Restart,
             ),
-            repeatMode = RepeatMode.Restart,
-        ),
-        label = "shimmer",
-    )
+            label = "shimmer",
+        )
 
-    val shimmerColors = listOf(
-        Color.White.copy(alpha = 0.3f),
-        Color.White.copy(alpha = 0.5f),
-        Color.White.copy(alpha = 0.3f),
-    )
+        val shimmerColors = listOf(
+            Color.White.copy(alpha = 0.3f),
+            Color.White.copy(alpha = 0.5f),
+            Color.White.copy(alpha = 0.3f),
+        )
 
-    val brush = Brush.linearGradient(
-        colors = shimmerColors,
-        start = Offset(shimmerTranslate - 300f, shimmerTranslate - 300f),
-        end = Offset(shimmerTranslate, shimmerTranslate),
-    )
+        Brush.linearGradient(
+            colors = shimmerColors,
+            start = Offset(shimmerTranslate - 300f, shimmerTranslate - 300f),
+            end = Offset(shimmerTranslate, shimmerTranslate),
+        )
+    } else {
+        Brush.linearGradient(
+            colors = listOf(
+                Color.White.copy(alpha = 0.34f),
+                Color.White.copy(alpha = 0.34f),
+            ),
+        )
+    }
 
     Column(
         modifier = modifier,

--- a/app/src/test/java/com/jjswigut/eventide/map/MapViewModelTest.kt
+++ b/app/src/test/java/com/jjswigut/eventide/map/MapViewModelTest.kt
@@ -42,6 +42,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -143,6 +144,22 @@ class MapViewModelTest {
         assertEquals("A tides", day?.date)
         assertNull(day?.weather)
         assertFalse(day?.isWeatherLoading ?: true)
+    }
+
+    @Test
+    fun `opening settings closes favorites and collapses expanded menu`() = runTest(testDispatcher) {
+        val viewModel = viewModel(FakeNoaaRepository())
+
+        viewModel.handleAction(MapAction.MenuClicked)
+        viewModel.handleAction(MapAction.OpenFavorites)
+        viewModel.handleAction(MapAction.MenuClicked)
+        viewModel.handleAction(MapAction.OpenSettings)
+        advanceUntilIdle()
+
+        val state = viewModel.viewState.value
+        assertTrue(state.showSettings)
+        assertFalse(state.showFavorites)
+        assertFalse(state.menuState.expanded)
     }
 
     private fun viewModel(repository: FakeNoaaRepository): MapViewModel {

--- a/app/src/test/java/com/jjswigut/eventide/map/components/TideGraphTest.kt
+++ b/app/src/test/java/com/jjswigut/eventide/map/components/TideGraphTest.kt
@@ -1,0 +1,15 @@
+package com.jjswigut.eventide.map.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TideGraphTest {
+    @Test
+    fun `visible tide samples clamp progress and keep an initial trace`() {
+        assertEquals(0, visibleTideSampleCount(totalSamples = 0, progress = 0f))
+        assertEquals(1, visibleTideSampleCount(totalSamples = 1, progress = 0f))
+        assertEquals(2, visibleTideSampleCount(totalSamples = 10, progress = -1f))
+        assertEquals(6, visibleTideSampleCount(totalSamples = 10, progress = 0.5f))
+        assertEquals(10, visibleTideSampleCount(totalSamples = 10, progress = 2f))
+    }
+}

--- a/tools/eventide_assert_screenshot.py
+++ b/tools/eventide_assert_screenshot.py
@@ -3,6 +3,12 @@ import struct
 import sys
 import zlib
 
+BLACK_OCCLUSION_LUMINANCE = 18
+BLACK_OCCLUSION_MAX_CHANNEL = 28
+BLACK_OCCLUSION_MIN_AREA = 20_000
+BLACK_OCCLUSION_MIN_WIDTH = 120
+BLACK_OCCLUSION_MIN_HEIGHT = 120
+
 
 def read_chunks(data):
     if data[:8] != b"\x89PNG\r\n\x1a\n":
@@ -78,6 +84,92 @@ def decode_png(path):
     return width, height, color_type, bytes_per_pixel, rows
 
 
+def pixel_rgb(row, offset, color_type):
+    if color_type == 0:
+        return row[offset], row[offset], row[offset]
+    if color_type == 4:
+        return row[offset], row[offset], row[offset]
+    return row[offset], row[offset + 1], row[offset + 2]
+
+
+def is_near_black(red, green, blue):
+    luminance = (0.2126 * red) + (0.7152 * green) + (0.0722 * blue)
+    return luminance <= BLACK_OCCLUSION_LUMINANCE and max(red, green, blue) <= BLACK_OCCLUSION_MAX_CHANNEL
+
+
+def find_black_occlusion(width, height, color_type, bytes_per_pixel, rows):
+    black_pixels = bytearray(width * height)
+    index = 0
+    for row in rows:
+        for offset in range(0, len(row), bytes_per_pixel):
+            red, green, blue = pixel_rgb(row, offset, color_type)
+            if is_near_black(red, green, blue):
+                black_pixels[index] = 1
+            index += 1
+
+    visited = bytearray(width * height)
+    largest = None
+    for start in range(width * height):
+        if visited[start] or not black_pixels[start]:
+            continue
+
+        stack = [start]
+        visited[start] = 1
+        area = 0
+        min_x = max_x = start % width
+        min_y = max_y = start // width
+
+        while stack:
+            current = stack.pop()
+            area += 1
+            x = current % width
+            y = current // width
+            min_x = min(min_x, x)
+            max_x = max(max_x, x)
+            min_y = min(min_y, y)
+            max_y = max(max_y, y)
+
+            if x > 0:
+                neighbor = current - 1
+                if black_pixels[neighbor] and not visited[neighbor]:
+                    visited[neighbor] = 1
+                    stack.append(neighbor)
+            if x < width - 1:
+                neighbor = current + 1
+                if black_pixels[neighbor] and not visited[neighbor]:
+                    visited[neighbor] = 1
+                    stack.append(neighbor)
+            if y > 0:
+                neighbor = current - width
+                if black_pixels[neighbor] and not visited[neighbor]:
+                    visited[neighbor] = 1
+                    stack.append(neighbor)
+            if y < height - 1:
+                neighbor = current + width
+                if black_pixels[neighbor] and not visited[neighbor]:
+                    visited[neighbor] = 1
+                    stack.append(neighbor)
+
+        component_width = max_x - min_x + 1
+        component_height = max_y - min_y + 1
+        if largest is None or area > largest["area"]:
+            largest = {
+                "area": area,
+                "width": component_width,
+                "height": component_height,
+                "x": min_x,
+                "y": min_y,
+            }
+        if (
+            area >= BLACK_OCCLUSION_MIN_AREA
+            and component_width >= BLACK_OCCLUSION_MIN_WIDTH
+            and component_height >= BLACK_OCCLUSION_MIN_HEIGHT
+        ):
+            return largest
+
+    return None
+
+
 def main(path):
     width, height, color_type, bytes_per_pixel, rows = decode_png(path)
     total = width * height
@@ -108,6 +200,14 @@ def main(path):
         raise ValueError(f"screenshot is mostly dark or blank: non_dark_ratio={non_dark_ratio:.3f}")
     if len(colors) < 8:
         raise ValueError(f"screenshot has too little visual variation: colors={len(colors)}")
+    black_occlusion = find_black_occlusion(width, height, color_type, bytes_per_pixel, rows)
+    if black_occlusion is not None:
+        raise ValueError(
+            "screenshot contains a large near-black occlusion: "
+            f"area={black_occlusion['area']}, "
+            f"bounds={black_occlusion['width']}x{black_occlusion['height']}"
+            f"+{black_occlusion['x']}+{black_occlusion['y']}"
+        )
 
     print(
         f"Screenshot check passed: {width}x{height}, "

--- a/tools/eventide_smoke.sh
+++ b/tools/eventide_smoke.sh
@@ -6,8 +6,12 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 AVD_NAME="${EVENTIDE_AVD_NAME:-EventideSmoke}"
 FORCE_EMULATOR="${EVENTIDE_FORCE_EMULATOR:-0}"
 SCREENSHOT_TIMEOUT_SECONDS="${EVENTIDE_SCREENSHOT_TIMEOUT_SECONDS:-30}"
+SCREENSHOT_SETTLE_SECONDS="${EVENTIDE_SCREENSHOT_SETTLE_SECONDS:-2}"
+SCREENSHOT_VALIDATION_ATTEMPTS="${EVENTIDE_SCREENSHOT_VALIDATION_ATTEMPTS:-5}"
 UI_DUMP_TIMEOUT_SECONDS="${EVENTIDE_UI_DUMP_TIMEOUT_SECONDS:-45}"
+UI_DUMP_COMMAND_TIMEOUT_SECONDS="${EVENTIDE_UI_DUMP_COMMAND_TIMEOUT_SECONDS:-10}"
 SMOKE_FIXTURE="${EVENTIDE_SMOKE_FIXTURE:-1}"
+ANIMATION_SCALE="${EVENTIDE_ANIMATION_SCALE:-}"
 PACKAGE_NAME="com.jjswigut.eventide"
 MAIN_ACTIVITY="com.jjswigut.eventide/.MainActivity"
 SMOKE_DIR="${REPO_ROOT}/build/smoke"
@@ -68,8 +72,9 @@ wait_for_boot() {
 }
 
 capture_screenshot() {
+  local screenshot_output="${1:-${SCREENSHOT_LOCAL}}"
   local screenshot_pid=""
-  adb -s "${ANDROID_SERIAL}" exec-out screencap -p > "${SCREENSHOT_LOCAL}" &
+  adb -s "${ANDROID_SERIAL}" exec-out screencap -p > "${screenshot_output}" &
   screenshot_pid=$!
 
   for _ in $(seq 1 "${SCREENSHOT_TIMEOUT_SECONDS}"); do
@@ -86,9 +91,92 @@ capture_screenshot() {
   return 1
 }
 
+capture_valid_screenshot() {
+  local attempt_path=""
+  local assertion_output=""
+  local last_assertion_output=""
+
+  for attempt in $(seq 1 "${SCREENSHOT_VALIDATION_ATTEMPTS}"); do
+    attempt_path="${SCREENSHOT_LOCAL%.png}-attempt-${attempt}.png"
+    rm -f "${attempt_path}"
+    capture_screenshot "${attempt_path}"
+
+    if [[ ! -s "${attempt_path}" ]]; then
+      last_assertion_output="Screenshot was not created or was empty: ${attempt_path}"
+      echo "Screenshot validation attempt ${attempt}/${SCREENSHOT_VALIDATION_ATTEMPTS} failed: ${last_assertion_output}" >&2
+      sleep "${SCREENSHOT_SETTLE_SECONDS}"
+      continue
+    fi
+
+    if assertion_output="$(python3 "${SCRIPT_DIR}/eventide_assert_screenshot.py" "${attempt_path}" 2>&1)"; then
+      mv "${attempt_path}" "${SCREENSHOT_LOCAL}"
+      rm -f "${SCREENSHOT_LOCAL%.png}-attempt-"*.png
+      echo "${assertion_output}"
+      return 0
+    fi
+
+    last_assertion_output="${assertion_output}"
+    echo "Screenshot validation attempt ${attempt}/${SCREENSHOT_VALIDATION_ATTEMPTS} failed: ${assertion_output}" >&2
+    sleep "${SCREENSHOT_SETTLE_SECONDS}"
+  done
+
+  echo "Timed out waiting for a valid screenshot after ${SCREENSHOT_VALIDATION_ATTEMPTS} attempts." >&2
+  echo "${last_assertion_output}" >&2
+  return 1
+}
+
+run_with_timeout() {
+  local timeout_seconds="$1"
+  shift
+  "$@" &
+  local command_pid=$!
+
+  for _ in $(seq 1 "${timeout_seconds}"); do
+    if ! kill -0 "${command_pid}" 2>/dev/null; then
+      wait "${command_pid}"
+      return $?
+    fi
+    sleep 1
+  done
+
+  kill "${command_pid}" >/dev/null 2>&1 || true
+  wait "${command_pid}" >/dev/null 2>&1 || true
+  return 124
+}
+
 dump_ui() {
-  adb -s "${ANDROID_SERIAL}" shell uiautomator dump "${UI_DUMP_REMOTE}" >/dev/null
-  adb -s "${ANDROID_SERIAL}" exec-out cat "${UI_DUMP_REMOTE}" > "${UI_DUMP_LOCAL}"
+  run_with_timeout "${UI_DUMP_COMMAND_TIMEOUT_SECONDS}" \
+    adb -s "${ANDROID_SERIAL}" shell uiautomator dump "${UI_DUMP_REMOTE}" >/dev/null
+  run_with_timeout "${UI_DUMP_COMMAND_TIMEOUT_SECONDS}" \
+    adb -s "${ANDROID_SERIAL}" exec-out cat "${UI_DUMP_REMOTE}" > "${UI_DUMP_LOCAL}"
+}
+
+set_animation_scale() {
+  if [[ -z "${ANIMATION_SCALE}" ]]; then
+    return 0
+  fi
+
+  local applied=0
+  for _ in {1..30}; do
+    if adb -s "${ANDROID_SERIAL}" shell settings put global window_animation_scale "${ANIMATION_SCALE}" \
+      && adb -s "${ANDROID_SERIAL}" shell settings put global transition_animation_scale "${ANIMATION_SCALE}" \
+      && adb -s "${ANDROID_SERIAL}" shell settings put global animator_duration_scale "${ANIMATION_SCALE}"; then
+      applied=1
+      break
+    fi
+    sleep 1
+  done
+
+  if [[ "${applied}" != "1" ]]; then
+    echo "Unable to apply Android animation scale '${ANIMATION_SCALE}' on target ${ANDROID_SERIAL}." >&2
+    return 1
+  fi
+
+  local window_scale transition_scale animator_scale
+  window_scale="$(adb -s "${ANDROID_SERIAL}" shell settings get global window_animation_scale | tr -d '\r')"
+  transition_scale="$(adb -s "${ANDROID_SERIAL}" shell settings get global transition_animation_scale | tr -d '\r')"
+  animator_scale="$(adb -s "${ANDROID_SERIAL}" shell settings get global animator_duration_scale | tr -d '\r')"
+  echo "Animation scales: window=${window_scale} transition=${transition_scale} animator=${animator_scale}"
 }
 
 wait_for_ui_text() {
@@ -117,6 +205,44 @@ tap_screen_center() {
   else
     adb -s "${ANDROID_SERIAL}" shell input tap "$((width / 2))" "$((height / 2))"
   fi
+}
+
+tap_ui_text_center() {
+  local expected="$1"
+  local coordinates=""
+
+  dump_ui || {
+    echo "Unable to dump UI before tapping '${expected}'." >&2
+    return 1
+  }
+
+  coordinates="$(
+    python3 - "${UI_DUMP_LOCAL}" "${expected}" <<'PY'
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+tree = ET.parse(sys.argv[1])
+expected = sys.argv[2]
+for node in tree.iter("node"):
+    if node.attrib.get("text") != expected and node.attrib.get("content-desc") != expected:
+        continue
+    bounds = node.attrib.get("bounds", "")
+    match = re.fullmatch(r"\[(\d+),(\d+)\]\[(\d+),(\d+)\]", bounds)
+    if not match:
+        continue
+    left, top, right, bottom = map(int, match.groups())
+    print((left + right) // 2, (top + bottom) // 2)
+    break
+PY
+  )"
+
+  if [[ -z "${coordinates}" ]]; then
+    echo "Unable to find UI text '${expected}' in ${UI_DUMP_LOCAL}." >&2
+    return 1
+  fi
+
+  adb -s "${ANDROID_SERIAL}" shell input tap ${coordinates}
 }
 
 assert_app_running() {
@@ -161,6 +287,7 @@ fi
 wait_for_boot "${ANDROID_SERIAL}"
 adb -s "${ANDROID_SERIAL}" shell input keyevent KEYCODE_WAKEUP >/dev/null 2>&1 || true
 adb -s "${ANDROID_SERIAL}" shell wm dismiss-keyguard >/dev/null 2>&1 || true
+set_animation_scale
 
 ./gradlew :app:assembleDebug
 
@@ -179,9 +306,7 @@ if [[ "${SMOKE_FIXTURE}" == "1" ]]; then
   adb -s "${ANDROID_SERIAL}" shell am start -W -n "${MAIN_ACTIVITY}" --ez eventide.SMOKE_FIXTURE true
   wait_for_ui_text "Open Smoke Station" "debug smoke fixture entry rendered"
   sleep 1
-  tap_screen_center
-  sleep 1
-  tap_screen_center
+  tap_ui_text_center "Open Smoke Station"
   wait_for_ui_text "Marine conditions" "station detail marine panel rendered"
   wait_for_ui_text "Buoy 44060 (12mi)" "deterministic NDBC buoy content rendered with distance"
   wait_for_ui_text "Tides" "station detail tide section rendered"
@@ -193,15 +318,12 @@ else
 fi
 assert_app_running
 
-SCREENSHOT_LOCAL="${SMOKE_DIR}/eventide-smoke-$(date +%Y%m%d-%H%M%S).png"
-capture_screenshot
-
-if [[ ! -s "${SCREENSHOT_LOCAL}" ]]; then
-  echo "Screenshot was not created or was empty: ${SCREENSHOT_LOCAL}" >&2
-  exit 1
+if [[ "${SCREENSHOT_SETTLE_SECONDS}" != "0" ]]; then
+  sleep "${SCREENSHOT_SETTLE_SECONDS}"
 fi
 
-python3 "${SCRIPT_DIR}/eventide_assert_screenshot.py" "${SCREENSHOT_LOCAL}"
+SCREENSHOT_LOCAL="${SMOKE_DIR}/eventide-smoke-$(date +%Y%m%d-%H%M%S).png"
+capture_valid_screenshot
 
 echo "Smoke target: ${ANDROID_SERIAL}"
 if [[ "${SMOKE_FIXTURE}" == "1" ]]; then


### PR DESCRIPTION
## Summary

Polishes Eventide's existing Compose interactions without adding new data sources or product surface area.

- Adds a shared, reduced-motion-aware Eventide motion helper for small spring entrances and confirmation moments.
- Adds the signature tide-graph interaction: the tide trace and a subtle under-curve water fill reveal like incoming water when station tide content appears, while disabled animations render the complete graph immediately.
- Calms supporting interactions: station detail/panel entrances, radial menu expansion, overlay/menu semantics, favorite confirmation pulse with one haptic, static loading placeholders when animations are disabled, and 48dp minimum chip/close targets in touched panels.
- Adds focused tests for animation-independent tide trace sample behavior and menu/panel state semantics.

## Interaction rationale

Audience: recreational boaters checking conditions quickly, often outdoors and one-handed.

Signature interaction: the tide graph behaves like the waterline. It draws the curve and fill progressively so the station detail feels rooted in tide behavior rather than generic screen decoration.

Supporting patterns: direct spring entrances for station detail and panels, a calmer radial overlay menu, a single favorite confirmation pulse/haptic, and reduced-motion fallbacks that preserve immediate access to tide, weather, alert, and marine information.

Deliberately omitted: no confetti, particles, sound, decorative loops, bouncing controls, broad color rebrand, new providers, navigation rewrite, or animation that repeats on every refresh.

## Verification

- Initial base/status: branch created from `origin/develop` at `8e20f25eb9be0df6113a97c1018b798044de3527`.
- `tools/eventide_verify.sh` passed.
- `EVENTIDE_FORCE_EMULATOR=1 EVENTIDE_STOP_EMULATOR=1 tools/eventide_smoke.sh` passed.
- `tools/eventide_release_check.sh` passed.
- Normal animation-scale interaction proof captured under `build/smoke/eventide-interaction-normal.mp4` and `build/smoke/eventide-interaction-normal-final.png`.
- Reduced-motion pass captured under `build/smoke/eventide-interaction-reduced-final.png` with window/transition/animator scales set to `0` before launch.
- Captured screenshots/frames were inspected for blank frames, clipping, overlap, and unreadable states; verification media is intentionally not committed.
