### PR TITLE
Fix and redesign marine conditions

### DIFF
--- a/app/src/main/kotlin/com/jjswigut/eventide/map/components/StationInfoRow.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/map/components/StationInfoRow.kt
@@ -11,13 +11,21 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -38,15 +46,19 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.jjswigut.eventide.R
+import com.jjswigut.eventide.data.models.BuoyConditions
 import com.jjswigut.eventide.data.models.MarineConditions
+import com.jjswigut.eventide.data.models.MarineObservation
 import com.jjswigut.eventide.data.models.Station
 import com.jjswigut.eventide.data.models.TideDay
 import com.jjswigut.eventide.map.MapAction
 import com.jjswigut.eventide.settings.AppSettings
 import com.jjswigut.eventide.ui.components.Action
 import com.jjswigut.eventide.ui.components.BodyText
+import com.jjswigut.eventide.ui.components.EnhancedBodyText
 import com.jjswigut.eventide.ui.components.EventideMotion
 import com.jjswigut.eventide.ui.components.SectionTitleText
 import com.jjswigut.eventide.ui.components.ShimmerLoading
@@ -73,7 +85,6 @@ private object StationInfoDesign {
     val cardPadding = 16.dp
     val marinePanelCornerRadius = 12.dp
     val marinePanelPadding = 12.dp
-    val marineChipCornerRadius = 8.dp
 }
 
 @Composable
@@ -88,15 +99,27 @@ fun StationInfoRow(
     actionHandler: (Action) -> Unit,
 ) {
     val density = LocalDensity.current
+    val configuration = LocalConfiguration.current
+    val statusBarPadding = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+    val detailScrollState = rememberScrollState()
     val entranceProgress = rememberEventideEntranceProgress(station?.id ?: list.firstOrNull()?.date)
+    val usableScreenHeight = configuration.screenHeightDp.dp - statusBarPadding
+    val detailViewportHeight = (usableScreenHeight - 72.dp).coerceAtLeast(480.dp)
+    val tideCardHeight = usableScreenHeight * 0.72f
+
+    LaunchedEffect(station?.id) {
+        detailScrollState.scrollTo(0)
+    }
 
     Column(
-        modifier = modifier.graphicsLayer {
-            alpha = entranceProgress
-            scaleX = DETAIL_MIN_SCALE + ((1f - DETAIL_MIN_SCALE) * entranceProgress)
-            scaleY = DETAIL_MIN_SCALE + ((1f - DETAIL_MIN_SCALE) * entranceProgress)
-            translationY = with(density) { DETAIL_ENTRANCE_OFFSET.toPx() } * (1f - entranceProgress)
-        },
+        modifier = modifier
+            .padding(top = statusBarPadding)
+            .graphicsLayer {
+                alpha = entranceProgress
+                scaleX = DETAIL_MIN_SCALE + ((1f - DETAIL_MIN_SCALE) * entranceProgress)
+                scaleY = DETAIL_MIN_SCALE + ((1f - DETAIL_MIN_SCALE) * entranceProgress)
+                translationY = with(density) { DETAIL_ENTRANCE_OFFSET.toPx() } * (1f - entranceProgress)
+            },
     ) {
         Row(
             modifier = Modifier.align(Alignment.End),
@@ -112,12 +135,24 @@ fun StationInfoRow(
             )
         }
 
-        MarineSummary(
-            marineConditions = marineConditions,
-            isLoading = isMarineConditionsLoading,
-        )
+        Column(
+            modifier = Modifier
+                .height(detailViewportHeight)
+                .verticalScroll(detailScrollState),
+        ) {
+            TideCardList(
+                list = list,
+                settings = settings,
+                cardHeight = tideCardHeight,
+            )
 
-        TideCardList(list = list, settings = settings)
+            MarineSummary(
+                marineConditions = marineConditions,
+                isLoading = isMarineConditionsLoading,
+            )
+
+            Spacer(Modifier.height(StationInfoDesign.cardSpacing))
+        }
     }
 }
 
@@ -126,8 +161,6 @@ private fun MarineSummary(
     marineConditions: MarineConditions?,
     isLoading: Boolean,
 ) {
-    if (!isLoading && marineConditions == null) return
-
     val boxWidth = LocalConfiguration.current.screenWidthDp - 48
 
     Column(
@@ -135,6 +168,7 @@ private fun MarineSummary(
             .padding(
                 start = StationInfoDesign.cardPadding,
                 end = StationInfoDesign.cardPadding,
+                top = StationInfoDesign.cardSpacing,
                 bottom = StationInfoDesign.cardSpacing,
             )
             .width(boxWidth.dp)
@@ -154,100 +188,172 @@ private fun MarineSummary(
             color = Color.White,
         )
 
-        if (isLoading) {
-            ShimmerLoading(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 8.dp),
-            )
-            return@Column
-        }
+        when {
+            isLoading -> {
+                ShimmerLoading(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 8.dp),
+                )
+            }
 
-        val conditions = marineConditions ?: return@Column
-        val chips = remember(conditions) { conditions.toMarineChips() }
+            marineConditions == null -> {
+                BodyText(
+                    modifier = Modifier.padding(top = 8.dp),
+                    text = "Marine conditions unavailable for this station.",
+                    color = Color.White.copy(alpha = 0.82f),
+                )
+            }
 
-        conditions.alerts.firstOrNull()?.let { alert ->
-            Text(
-                modifier = Modifier.padding(top = 8.dp),
-                text = "${alert.event}: ${alert.severity}",
-                color = Color(0xFFFFD166),
-                fontWeight = FontWeight.Bold,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-            BodyText(
-                text = alert.headline,
-                color = Color.White,
-                maxLines = 2,
-            )
-            BodyText(
-                text = alert.sourceAttribution(),
-                color = Color.White.copy(alpha = 0.78f),
-                maxLines = 1,
-            )
-        }
-
-        if (chips.isNotEmpty()) {
-            LazyRow(
-                modifier = Modifier.padding(top = 8.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                items(chips) { chip ->
-                    MarineChip(chip)
-                }
+            else -> {
+                MarineConditionsContent(marineConditions)
             }
         }
     }
 }
 
 @Composable
-private fun MarineChip(text: String) {
-    Text(
+private fun MarineConditionsContent(conditions: MarineConditions) {
+    val now = remember(conditions) { Instant.now() }
+    var hasPreviousSection = false
+
+    conditions.alerts.firstOrNull()?.let { alert ->
+        Text(
+            modifier = Modifier.padding(top = 8.dp),
+            text = "${alert.event}: ${alert.severity}",
+            color = Color(0xFFFFD166),
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        BodyText(
+            text = alert.headline,
+            color = Color.White,
+            maxLines = 2,
+        )
+        BodyText(
+            text = alert.sourceAttribution(),
+            color = Color.White.copy(alpha = 0.72f),
+            maxLines = 1,
+        )
+        hasPreviousSection = true
+    }
+
+    conditions.buoy?.let { buoy ->
+        MarineSectionDivider(visible = hasPreviousSection)
+        MarineBuoySection(buoy = buoy, now = now)
+        hasPreviousSection = true
+    }
+
+    conditions.observations.take(4).forEach { observation ->
+        MarineSectionDivider(visible = hasPreviousSection)
+        MarineObservationSection(observation = observation, now = now)
+        hasPreviousSection = true
+    }
+
+    if (conditions.alerts.size > 1) {
+        MarineSectionDivider(visible = hasPreviousSection)
+        BodyText(
+            text = "${conditions.alerts.size} active marine alerts",
+            color = Color.White.copy(alpha = 0.82f),
+        )
+    }
+}
+
+@Composable
+private fun MarineBuoySection(buoy: BuoyConditions, now: Instant) {
+    Row(
         modifier = Modifier
-            .background(
-                color = PrimaryLight.copy(alpha = 0.25f),
-                shape = RoundedCornerShape(StationInfoDesign.marineChipCornerRadius),
+            .fillMaxWidth()
+            .padding(top = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.Top,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            EnhancedBodyText(
+                text = "Nearby buoy ${buoy.stationId}",
+                color = Color.White,
+                fontWeight = FontWeight.Bold,
             )
-            .padding(horizontal = 10.dp, vertical = 6.dp),
-        text = text,
-        color = Color.White,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
+            BodyText(
+                text = buoy.stationName,
+                color = Color.White.copy(alpha = 0.76f),
+                maxLines = 2,
+            )
+        }
+        EnhancedBodyText(
+            modifier = Modifier.padding(start = 12.dp),
+            text = "${String.format(Locale.US, "%.0f", buoy.distanceMiles)} mi",
+            color = Color.White,
+            fontWeight = FontWeight.Bold,
+        )
+    }
+
+    listOfNotNull(
+        buoy.wind?.let { "Wind" to it },
+        buoy.waveHeight?.let { "Waves" to it },
+        buoy.wavePeriod?.let { "Period" to it },
+        buoy.waterTemperature?.let { "Water" to it },
+        buoy.pressure?.let { "Pressure" to it },
+    ).forEach { (label, value) ->
+        MarineDataRow(label = label, value = value)
+    }
+
+    MarineMetadata(
+        source = buoy.source,
+        freshness = buoy.observedAt.marineFreshnessLabel(now, BUOY_STALE_AFTER),
     )
 }
 
-internal fun MarineConditions.toMarineChips(now: Instant = Instant.now()): List<String> {
-    val chips = mutableListOf<String>()
-    buoy?.let { buoy ->
-        val distance = String.format(Locale.US, "%.0f", buoy.distanceMiles)
-        val details = listOfNotNull(
-            buoy.waveHeight?.let { "waves $it" },
-            buoy.wind?.let { "wind $it" },
-            buoy.waterTemperature?.let { "water $it" },
-            buoy.pressure?.let { "pressure $it" },
-        ).joinToString(", ")
-        val source = listOfNotNull(
-            "${buoy.source} ${buoy.sourceType.lowercase(Locale.US)}",
-            buoy.observedAt.freshnessLabel(now, BUOY_STALE_AFTER),
-        ).joinToString(" - ")
-        val summary = if (details.isBlank()) {
-            "Buoy ${buoy.stationId} (${distance}mi)"
-        } else {
-            "Buoy ${buoy.stationId} (${distance}mi): $details"
-        }
-        chips += listOfNotNull(summary, source.takeIf { it.isNotBlank() }).joinToString(" - ")
+@Composable
+private fun MarineObservationSection(observation: MarineObservation, now: Instant) {
+    MarineDataRow(label = observation.label, value = observation.value)
+    MarineMetadata(
+        source = observation.source,
+        freshness = observation.observedAt.marineFreshnessLabel(now, OBSERVATION_STALE_AFTER),
+    )
+}
+
+@Composable
+private fun MarineDataRow(label: String, value: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        BodyText(
+            modifier = Modifier.weight(1f),
+            text = label,
+            color = Color.White.copy(alpha = 0.78f),
+        )
+        EnhancedBodyText(
+            modifier = Modifier.padding(start = 12.dp),
+            text = value,
+            color = Color.White,
+            fontWeight = FontWeight.SemiBold,
+        )
     }
-    observations.take(4).forEach { observation ->
-        chips += listOfNotNull(
-            "${observation.label}: ${observation.value}",
-            "${observation.source} ${observation.sourceType.lowercase(Locale.US)}",
-            observation.observedAt.freshnessLabel(now, OBSERVATION_STALE_AFTER),
-        ).joinToString(" - ")
-    }
-    if (alerts.size > 1) {
-        chips += "${alerts.size} active NWS alerts"
-    }
-    return chips
+}
+
+@Composable
+private fun MarineMetadata(source: String, freshness: String?) {
+    BodyText(
+        modifier = Modifier.padding(top = 2.dp),
+        text = listOfNotNull(source, freshness).joinToString(" - "),
+        color = Color.White.copy(alpha = 0.64f),
+        maxLines = 1,
+    )
+}
+
+@Composable
+private fun MarineSectionDivider(visible: Boolean) {
+    if (!visible) return
+    HorizontalDivider(
+        modifier = Modifier.padding(vertical = 8.dp),
+        color = PrimaryLight.copy(alpha = 0.32f),
+    )
 }
 
 private fun com.jjswigut.eventide.data.models.MarineAlert.sourceAttribution(): String {
@@ -258,11 +364,16 @@ private fun com.jjswigut.eventide.data.models.MarineAlert.sourceAttribution(): S
     return listOf(source, timing.takeIf { it.isNotBlank() }).joinToString(" - ")
 }
 
-private fun Instant?.freshnessLabel(now: Instant, staleAfter: Duration): String? {
+internal fun Instant?.marineFreshnessLabel(now: Instant, staleAfter: Duration): String? {
     val observedAt = this ?: return null
-    val age = Duration.between(observedAt, now)
-    val freshness = if (age > staleAfter) "stale" else "current"
-    return "${observedAt.shortUtcLabel()} UTC $freshness"
+    val age = Duration.between(observedAt, now).coerceAtLeast(Duration.ZERO)
+    val ageLabel = when {
+        age.toMinutes() < 1 -> "Updated now"
+        age.toMinutes() < 60 -> "Updated ${age.toMinutes()}m ago"
+        age.toHours() < 24 -> "Updated ${age.toHours()}h ago"
+        else -> "Updated ${age.toDays()}d ago"
+    }
+    return if (age > staleAfter) "$ageLabel - Stale" else ageLabel
 }
 
 private fun Instant.shortUtcLabel(): String {
@@ -384,6 +495,7 @@ private const val DETAIL_MIN_SCALE = 0.965f
 private fun TideCardList(
     list: List<TideDay>,
     settings: AppSettings,
+    cardHeight: Dp,
 ) {
     LazyRow(
         contentPadding = PaddingValues(
@@ -393,7 +505,11 @@ private fun TideCardList(
         horizontalArrangement = Arrangement.spacedBy(StationInfoDesign.cardSpacing),
     ) {
         items(list) { day ->
-            TideCard(day = day, settings = settings)
+            TideCard(
+                modifier = Modifier.height(cardHeight),
+                day = day,
+                settings = settings,
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/jjswigut/eventide/map/components/TideCard.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/map/components/TideCard.kt
@@ -47,9 +47,6 @@ import com.jjswigut.eventide.ui.components.SectionTitleText
 import com.jjswigut.eventide.ui.components.ShimmerLoading
 import com.jjswigut.eventide.ui.theme.BackgroundDark
 import com.jjswigut.eventide.ui.theme.PrimaryLight
-import java.time.OffsetDateTime
-import java.time.format.DateTimeFormatter
-import java.util.Locale
 import kotlin.math.max
 import kotlin.math.min
 
@@ -110,6 +107,7 @@ private object TemperatureColors {
 
 @Composable
 fun TideCard(
+    modifier: Modifier = Modifier.fillMaxHeight(.8f),
     day: TideDay,
     settings: AppSettings,
 ) {
@@ -117,8 +115,7 @@ fun TideCard(
 
     @Suppress("UnusedBoxWithConstraintsScope")
     BoxWithConstraints(
-        modifier = Modifier
-            .fillMaxHeight(.8f)
+        modifier = modifier
             .width(boxWidth.dp)
             .background(
                 color = BackgroundDark.copy(alpha = TideCardDesign.cardBackgroundAlpha),
@@ -471,27 +468,8 @@ private fun WeatherContent(
 }
 
 private fun Weather.sourceLabel(): String {
-    val validity = forecastStart?.let { start ->
-        val end = forecastEnd
-        if (end == null) {
-            "valid ${start.shortLabel()}"
-        } else {
-            "valid ${start.shortLabel()}-${end.shortLabel()}"
-        }
-    }
-    val issued = forecastIssuedAt?.let { "issued ${it.shortLabel()}" }
-    return listOfNotNull(
-        "$source ${sourceType.lowercase(Locale.US)}",
-        validity,
-        issued,
-    ).joinToString(" - ")
+    return source
 }
-
-private fun OffsetDateTime.shortLabel(): String {
-    return forecastTimeFormatter.format(this)
-}
-
-private val forecastTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("MMM d h:mma", Locale.US)
 
 @Composable
 private fun TemperatureBox(

--- a/app/src/main/kotlin/com/jjswigut/eventide/network/service/MarineServiceImpl.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/network/service/MarineServiceImpl.kt
@@ -115,9 +115,10 @@ class MarineServiceImpl(
                 .minByOrNull { (_, distance) -> distance }
                 ?: return null
 
-            val latestText = client.getNdbcRealtimeText(nearest.first.id).bodyAsText()
+            val station = nearest.first.copy(id = nearest.first.id.uppercase(Locale.US))
+            val latestText = client.getNdbcRealtimeText(station.id).bodyAsText()
             parseNdbcRealtimeText(
-                station = nearest.first,
+                station = station,
                 distanceMiles = nearest.second,
                 text = latestText,
             )

--- a/app/src/test/java/com/jjswigut/eventide/map/components/StationInfoRowTest.kt
+++ b/app/src/test/java/com/jjswigut/eventide/map/components/StationInfoRowTest.kt
@@ -1,34 +1,25 @@
 package com.jjswigut.eventide.map.components
 
-import com.jjswigut.eventide.data.models.BuoyConditions
-import com.jjswigut.eventide.data.models.MarineConditions
-import com.jjswigut.eventide.data.models.MarineObservation
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.time.Duration
 import java.time.Instant
 
 class StationInfoRowTest {
     @Test
-    fun `toMarineChips includes source freshness and buoy distance with readings`() {
-        val chips = MarineConditions(
-            observations = listOf(
-                MarineObservation(
-                    label = "Water",
-                    value = "64.1°F",
-                    observedAt = Instant.parse("2026-07-07T18:50:00Z"),
-                ),
-            ),
-            buoy = BuoyConditions(
-                stationId = "44060",
-                stationName = "Eastern Long Island Sound",
-                distanceMiles = 12.4,
-                waveHeight = "3.9ft",
-                observedAt = Instant.parse("2026-07-07T12:00:00Z"),
-            ),
-        ).toMarineChips(now = Instant.parse("2026-07-07T18:50:00Z"))
+    fun `marine freshness uses concise relative labels and marks stale data`() {
+        val now = Instant.parse("2026-07-07T18:50:00Z")
 
-        assertTrue(chips.any { it.contains("NOAA CO-OPS observation") && it.contains("current") })
-        assertTrue(chips.any { it.contains("Buoy 44060 (12mi): waves 3.9ft") })
-        assertTrue(chips.any { it.contains("NDBC buoy observation") && it.contains("stale") })
+        assertEquals("Updated now", now.marineFreshnessLabel(now, Duration.ofHours(3)))
+        assertEquals(
+            "Updated 6h ago - Stale",
+            Instant.parse("2026-07-07T12:00:00Z").marineFreshnessLabel(now, Duration.ofHours(3)),
+        )
+        assertTrue(
+            Instant.parse("2026-07-07T18:20:00Z")
+                .marineFreshnessLabel(now, Duration.ofHours(3))
+                ?.contains("30m") == true,
+        )
     }
 }

--- a/app/src/test/java/com/jjswigut/eventide/network/service/MarineServiceImplTest.kt
+++ b/app/src/test/java/com/jjswigut/eventide/network/service/MarineServiceImplTest.kt
@@ -1,6 +1,7 @@
 package com.jjswigut.eventide.network.service
 
 import com.jjswigut.eventide.network.client.MarineServiceClient
+import com.jjswigut.eventide.network.utils.Either
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpHeaders
@@ -122,13 +123,13 @@ class MarineServiceImplTest {
                             content = """
                                 <?xml version="1.0" encoding="utf-8"?>
                                 <stations>
-                                  <station id="44060" lat="41.263" lon="-72.067" name="Eastern Long Island Sound" met="y"/>
+                                  <station id="nlhc3" lat="41.263" lon="-72.067" name="New London" met="y"/>
                                 </stations>
                             """.trimIndent(),
                             headers = headersOf(HttpHeaders.ContentType, "application/xml"),
                         )
                     }
-                    url.endsWith("/data/realtime2/44060.txt") -> respond(
+                    url.endsWith("/data/realtime2/NLHC3.txt") -> respond(
                         content = """
                             #YY  MM DD hh mm WDIR WSPD GST WVHT DPD PRES WTMP
                             2026 07 07 18 50 220  5.0 7.0 1.2 8 1013.4 18.1
@@ -148,9 +149,11 @@ class MarineServiceImplTest {
         )
         val service = MarineServiceImpl(client)
 
-        service.getMarineConditions("8461490", 41.3, -72.0)
+        val result = service.getMarineConditions("8461490", 41.3, -72.0)
         service.getMarineConditions("8461490", 41.3, -72.0)
 
+        require(result is Either.Success)
+        assertEquals("NLHC3", result.value.buoy?.stationId)
         assertEquals(1, activeStationsRequests.get())
     }
 }

--- a/release-notes/2.03.md
+++ b/release-notes/2.03.md
@@ -1,5 +1,6 @@
 Eventide 2.03 hardens station details for release:
 
+- Marine conditions now load nearby NDBC buoy readings reliably and appear in a structured card below Weather.
 - Station detail panels now ignore stale tide, forecast, and marine responses after switching or closing stations.
 - Marine conditions show source attribution, observation times, stale labels, and buoy distance whenever buoy readings appear.
 - NOAA/NWS/NDBC network calls now have tighter timeouts and partial-source failures degrade independently.

--- a/tools/eventide_smoke.sh
+++ b/tools/eventide_smoke.sh
@@ -308,10 +308,12 @@ if [[ "${SMOKE_FIXTURE}" == "1" ]]; then
   sleep 1
   tap_ui_text_center "Open Smoke Station"
   wait_for_ui_text "Marine conditions" "station detail marine panel rendered"
-  wait_for_ui_text "Buoy 44060 (12mi)" "deterministic NDBC buoy content rendered with distance"
+  wait_for_ui_text "Nearby buoy 44060" "deterministic NDBC buoy content rendered"
+  wait_for_ui_text "12 mi" "deterministic NDBC buoy distance rendered"
+  wait_for_ui_text "Waves" "structured marine metric rows rendered"
   wait_for_ui_text "Tides" "station detail tide section rendered"
   wait_for_ui_text "1:14am" "deterministic tide content rendered"
-  wait_for_ui_text "National Weather Service forecast" "deterministic weather forecast attribution rendered"
+  wait_for_ui_text "National Weather Service" "deterministic weather attribution rendered"
 else
   adb -s "${ANDROID_SERIAL}" shell am start -W -n "${MAIN_ACTIVITY}"
   wait_for_ui_text "Eventide" "normal app launched"


### PR DESCRIPTION
## Summary
- fix case-sensitive NDBC realtime requests by normalizing active-station IDs
- move marine conditions below Weather in the vertically scrollable station detail
- replace horizontal comma-heavy chips with structured metric rows and relative freshness
- keep an unavailable marine state visible instead of removing the panel
- simplify Weather attribution to the source name
- update deterministic smoke assertions and 2.03 release notes

## Verification
- focused marine service, ViewModel, and station-row tests
- `tools/eventide_verify.sh`
- `tools/eventide_release_check.sh` on isolated `emulator-5556`
- clean top and scrolled screenshots visually inspected
- disposable proof AVD removed after verification