### PR TITLE
Enforce Google Play release note limit

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -57,6 +57,12 @@ jobs:
             echo "::error::Release notes file not found: $RELEASE_NOTES_FILE"
             exit 1
           fi
+          RELEASE_NOTES_LENGTH=$(wc -m < "$RELEASE_NOTES_FILE" | tr -d ' ')
+          if (( RELEASE_NOTES_LENGTH > 500 )); then
+            echo "::error::Release notes are $RELEASE_NOTES_LENGTH characters; Google Play allows at most 500."
+            exit 1
+          fi
+          echo "Validated Google Play release notes length: $RELEASE_NOTES_LENGTH/500"
           echo "RELEASE_NOTES_FILE=$RELEASE_NOTES_FILE" >> $GITHUB_OUTPUT
           {
             echo "RELEASE_NOTES<<EOF"

--- a/release-notes/2.03.md
+++ b/release-notes/2.03.md
@@ -1,8 +1,7 @@
-Eventide 2.03 hardens station details for release:
+Eventide 2.03 makes station details more reliable and easier to scan:
 
-- Marine conditions now load nearby NDBC buoy readings reliably and appear in a structured card below Weather.
-- Station detail panels now ignore stale tide, forecast, and marine responses after switching or closing stations.
-- Marine conditions show source attribution, observation times, stale labels, and buoy distance whenever buoy readings appear.
-- NOAA/NWS/NDBC network calls now have tighter timeouts and partial-source failures degrade independently.
-- The non-commercial-only Open-Meteo Marine fallback has been removed while licensing is reviewed.
-- Release smoke checks now verify a rendered station-detail state instead of taking a fixed-delay screenshot.
+- Marine conditions now load nearby NDBC buoy observations reliably in a structured card below Weather.
+- Tide, forecast, and marine requests ignore stale responses when switching stations.
+- Marine observations include source, time, freshness, and buoy distance.
+- NOAA, NWS, and NDBC failures degrade independently with tighter timeouts.
+- Release smoke tests now verify rendered station details.


### PR DESCRIPTION
## Summary
- shorten Eventide 2.03 release notes to 470 characters
- reject release notes over Google Play's 500-character limit before signing or publishing

## Verification
- tools/eventide_release_check.sh
- workflow YAML parsed successfully
- git diff --check

## Release recovery
Run 29296175535 passed release checks, signed AAB creation, and GitHub release creation, but Google Play rejected its 721-character changelog. This prevents that failure before artifact creation.