### PR TITLE
Release Eventide 2.03 build 23

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -57,6 +57,12 @@ jobs:
             echo "::error::Release notes file not found: $RELEASE_NOTES_FILE"
             exit 1
           fi
+          RELEASE_NOTES_LENGTH=$(wc -m < "$RELEASE_NOTES_FILE" | tr -d ' ')
+          if (( RELEASE_NOTES_LENGTH > 500 )); then
+            echo "::error::Release notes are $RELEASE_NOTES_LENGTH characters; Google Play allows at most 500."
+            exit 1
+          fi
+          echo "Validated Google Play release notes length: $RELEASE_NOTES_LENGTH/500"
           echo "RELEASE_NOTES_FILE=$RELEASE_NOTES_FILE" >> $GITHUB_OUTPUT
           {
             echo "RELEASE_NOTES<<EOF"

--- a/release-notes/2.03.md
+++ b/release-notes/2.03.md
@@ -1,8 +1,7 @@
-Eventide 2.03 hardens station details for release:
+Eventide 2.03 makes station details more reliable and easier to scan:
 
-- Marine conditions now load nearby NDBC buoy readings reliably and appear in a structured card below Weather.
-- Station detail panels now ignore stale tide, forecast, and marine responses after switching or closing stations.
-- Marine conditions show source attribution, observation times, stale labels, and buoy distance whenever buoy readings appear.
-- NOAA/NWS/NDBC network calls now have tighter timeouts and partial-source failures degrade independently.
-- The non-commercial-only Open-Meteo Marine fallback has been removed while licensing is reviewed.
-- Release smoke checks now verify a rendered station-detail state instead of taking a fixed-delay screenshot.
+- Marine conditions now load nearby NDBC buoy observations reliably in a structured card below Weather.
+- Tide, forecast, and marine requests ignore stale responses when switching stations.
+- Marine observations include source, time, freshness, and buoy distance.
+- NOAA, NWS, and NDBC failures degrade independently with tighter timeouts.
+- Release smoke tests now verify rendered station details.


### PR DESCRIPTION
## Release

Publishes Eventide 2.03 with the verified marine/weather/tide improvements and corrected Google Play release metadata.

## Recovery from build 22

Release run 29296175535 passed checks, signing, AAB creation, and GitHub release creation, but Google Play rejected the 721-character changelog. PR #7 shortens it to 470 characters and adds a 500-character pre-publish guard.

## Verification

- tools/eventide_release_check.sh passed on exact hotfix commit 6b72712
- emulator station-detail, NDBC, tide, and NWS assertions passed
- screenshot validation passed
- release tests and lintVitalRelease passed
- PR #7 Android CI passed

Merging triggers Android CI/CD Release and deploys to the configured Google Play internal track with completed status.