### PR TITLE
Add production track promotion workflow

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -12,6 +12,16 @@ on:
           - release
           - validate-store-listing
           - publish-store-listing
+          - promote-to-production
+      version_code:
+        description: Existing Google Play version code to promote
+        required: false
+        type: string
+      rollout:
+        description: Production rollout fraction from 0 to 1
+        required: false
+        default: '1.0'
+        type: string
   push:
     branches:
       - main # Triggers on pushes to the main branch
@@ -186,3 +196,31 @@ jobs:
         env:
           GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
         run: bundle exec fastlane android store_listing validate_only:false
+
+  promote-to-production:
+    name: Promote build ${{ inputs.version_code }} to production
+    if: github.event_name == 'workflow_dispatch' && inputs.operation == 'promote-to-production'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Install Fastlane dependencies
+        run: bundle install --jobs 4 --retry 3
+
+      - name: Promote existing Google Play release
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          PLAY_VERSION_CODE: ${{ inputs.version_code }}
+          PLAY_SOURCE_TRACK: internal
+          PLAY_DESTINATION_TRACK: production
+          PLAY_ROLLOUT: ${{ inputs.rollout }}
+        run: bundle exec fastlane android promote

--- a/docs/google-play-listing.md
+++ b/docs/google-play-listing.md
@@ -56,5 +56,11 @@ Publishing requires an explicit owner decision. Pushes to `main` and manual
 `release` runs continue to build and upload the AAB and version-specific
 changelog; listing operations skip the release job entirely.
 
+To promote an already-tested build without creating a new AAB, choose
+`promote-to-production`, supply its Google Play version code, and set the
+rollout fraction. The promotion lane validates the existing version code and
+promotes it from `internal` to `production` without uploading app binaries or
+store metadata.
+
 Google Play asset guidance:
 https://support.google.com/googleplay/android-developer/answer/9866151?hl=en

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -68,4 +68,34 @@ platform :android do
       validate_only: validate_only
     )
   end
+
+  desc "Promote an existing Google Play release between tracks"
+  lane :promote do |options|
+    version_code = (options[:version_code] || ENV["PLAY_VERSION_CODE"]).to_s.strip
+    source_track = (options[:source_track] || ENV["PLAY_SOURCE_TRACK"] || "internal").to_s.strip
+    destination_track = (options[:destination_track] || ENV["PLAY_DESTINATION_TRACK"] || "production").to_s.strip
+    rollout = (options[:rollout] || ENV["PLAY_ROLLOUT"] || "1.0").to_s.strip
+
+    UI.user_error!("Set PLAY_VERSION_CODE to the existing release version code.") unless version_code.match?(/\A[1-9]\d*\z/)
+    UI.user_error!("Source and destination tracks must differ.") if source_track == destination_track
+
+    rollout_fraction = Float(rollout, exception: false)
+    UI.user_error!("PLAY_ROLLOUT must be greater than 0 and at most 1.") unless rollout_fraction&.positive? && rollout_fraction <= 1
+
+    upload_to_play_store(
+      package_name: "com.jjswigut.eventide",
+      json_key_data: google_play_json_key_data,
+      track: source_track,
+      track_promote_to: destination_track,
+      version_code: version_code.to_i,
+      rollout: rollout_fraction,
+      track_promote_release_status: "completed",
+      skip_upload_apk: true,
+      skip_upload_aab: true,
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true
+    )
+  end
 end


### PR DESCRIPTION
## Summary
- add an explicit `promote-to-production` workflow operation for an existing Google Play version code
- promote from `internal` to `production` without building or uploading another AAB
- validate version code and rollout fraction before contacting Google Play

## Verification
- workflow YAML parsing
- Fastfile Ruby syntax
- `bundle exec fastlane lanes`
- invalid version-code and rollout guard tests
- `python3 tools/eventide_validate_store_listing.py`
- `git diff --check`

## Intended dispatch
After merge, promote existing version code `23` from `internal` to `production` with rollout `1.0`. The owner explicitly approved this production mutation.
