### PR TITLE
Fix Google Play promotion rollout type

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -88,7 +88,7 @@ platform :android do
       track: source_track,
       track_promote_to: destination_track,
       version_code: version_code.to_i,
-      rollout: rollout_fraction,
+      rollout: rollout,
       track_promote_release_status: "completed",
       skip_upload_apk: true,
       skip_upload_aab: true,


### PR DESCRIPTION
## Summary
- preserve the validated rollout fraction as the string type required by Fastlane Supply

## Root cause
The first production-promotion run failed before opening a Play edit because `upload_to_play_store` requires `rollout` to be a String and the lane passed a Float.

## Verification
- Fastfile Ruby syntax
- `git diff --check`
- valid version `23`, tracks `internal` to `production`, and rollout `1.0` now pass Fastlane parameter validation and reach the expected local credential gate
- no Play edit or release mutation occurred in the failed run
