### PR TITLE
Release Eventide 2.05

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
 
+      - name: Verify database migrations
+        run: python3 tools/verify_database_migrations.py
+
       - name: Verify
         run: ./gradlew :app:compileDebugKotlin :app:spotlessCheck :app:testDebugUnitTest :app:assembleDebug

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -108,7 +108,9 @@ jobs:
           echo "Keystore and properties file created."
 
       - name: Run release checks
-        run: ./gradlew :app:spotlessCheck :app:testReleaseUnitTest :app:lintVitalRelease
+        run: |
+          python3 tools/verify_database_migrations.py
+          ./gradlew :app:spotlessCheck :app:testReleaseUnitTest :app:lintVitalRelease
 
       - name: Build Signed AAB
         id: build_aab

--- a/app/src/main/kotlin/com/jjswigut/eventide/network/client/NoaaServiceClient.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/network/client/NoaaServiceClient.kt
@@ -49,12 +49,23 @@ class NoaaServiceClient(engine: HttpClientEngine) {
         parameter("station", stationID)
     }
 
+    suspend fun getTidesByRange(
+        startDate: String,
+        rangeHours: Int,
+        stationID: String,
+    ) = client.get {
+        url(base_url + tides_url)
+        parameter("begin_date", startDate)
+        parameter("range", rangeHours)
+        parameter("station", stationID)
+    }
+
     companion object {
         private const val base_url = "https://api.tidesandcurrents.noaa.gov/"
         private const val stations_url =
             "mdapi/prod/webapi/stations.json?type=tidepredictions&units=english"
         private const val tides_url =
-            "api/prod/datagetter?product=predictions&application=NOS.COOPS.TAC.WL&datum=MLLW&time_zone=lst_ldt&units=metric&interval=hilo&format=json"
+            "api/prod/datagetter?product=predictions&application=Eventide&datum=MLLW&time_zone=lst_ldt&units=metric&interval=hilo&format=json"
         private const val USER_AGENT = "Eventide/1.0 (jjswigut@gmail.com)"
         private const val CONNECT_TIMEOUT_MS = 10_000L
         private const val REQUEST_TIMEOUT_MS = 30_000L

--- a/app/src/main/kotlin/com/jjswigut/eventide/network/responses/TidesResponse.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/network/responses/TidesResponse.kt
@@ -12,8 +12,14 @@ import java.util.Locale
 
 @Serializable
 data class TidesResponse(
-    val predictions: List<TideDTO>,
+    val predictions: List<TideDTO> = emptyList(),
+    val error: ErrorDTO? = null,
 ) {
+    @Serializable
+    data class ErrorDTO(
+        val message: String = "",
+    )
+
     @Serializable
     data class TideDTO(
         val t: String,

--- a/app/src/main/kotlin/com/jjswigut/eventide/network/service/NoaaServiceImpl.kt
+++ b/app/src/main/kotlin/com/jjswigut/eventide/network/service/NoaaServiceImpl.kt
@@ -9,6 +9,7 @@ import com.jjswigut.eventide.utils.GenericError
 import com.jjswigut.eventide.utils.UnknownError
 import io.ktor.client.call.body
 import io.ktor.client.plugins.ResponseException
+import kotlinx.coroutines.delay
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -37,29 +38,59 @@ class NoaaServiceImpl(
     override suspend fun getTidesForStation(stationID: String): Either<TidesResponse, GenericError> {
         val startDate = LocalDate.now()
         val endDate = startDate.plusDays(7)
-
-        return runCatching {
-            client.getTides(
-                startDate = startDate.format(dateFormatter),
-                endDate = endDate.format(dateFormatter),
-                stationID = stationID,
-            ).body<TidesResponse>()
-        }.fold(
-            onSuccess = { response ->
-                Either.success(response)
+        val formattedStartDate = startDate.format(dateFormatter)
+        val formattedEndDate = endDate.format(dateFormatter)
+        val requests = listOf<suspend () -> TidesResponse>(
+            {
+                client.getTides(
+                    startDate = formattedStartDate,
+                    endDate = formattedEndDate,
+                    stationID = stationID,
+                ).body()
             },
-            onFailure = { throwable ->
-                val error = if (throwable is ResponseException) {
+            {
+                client.getTidesByRange(
+                    startDate = formattedStartDate,
+                    rangeHours = TIDE_RANGE_HOURS,
+                    stationID = stationID,
+                ).body()
+            },
+            {
+                client.getTides(
+                    startDate = formattedStartDate,
+                    endDate = formattedEndDate,
+                    stationID = stationID,
+                ).body()
+            },
+        )
+        var lastError: GenericError = UnknownError()
+
+        requests.forEachIndexed { index, request ->
+            val result = runCatching { request() }
+            val response = result.getOrNull()
+            if (response != null && response.error == null && response.predictions.isNotEmpty()) {
+                return Either.success(response)
+            }
+
+            result.exceptionOrNull()?.let { throwable ->
+                lastError = if (throwable is ResponseException) {
                     NetworkError(code = throwable.response.status.value)
                 } else {
                     UnknownError()
                 }
-                Either.failure(error)
-            },
-        )
+            }
+
+            retryDelaysMillis.getOrNull(index)?.let { delayMillis ->
+                delay(delayMillis)
+            }
+        }
+
+        return Either.failure(lastError)
     }
 
     companion object {
         private val dateFormatter = DateTimeFormatter.ofPattern("yyyyMMdd", Locale.US)
+        private val retryDelaysMillis = listOf(350L, 900L)
+        private const val TIDE_RANGE_HOURS = 192
     }
 }

--- a/app/src/main/sqldelight/com/jjswigut/eventide/db/1.sqm
+++ b/app/src/main/sqldelight/com/jjswigut/eventide/db/1.sqm
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS FavoriteStationEntity (
+   id TEXT PRIMARY KEY,
+   latitude REAL NOT NULL,
+   longitude REAL NOT NULL,
+   name TEXT NOT NULL,
+   state TEXT NOT NULL,
+   created_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS TideAlertPreferenceEntity (
+   station_id TEXT PRIMARY KEY,
+   lead_time_minutes INTEGER NOT NULL,
+   tide_filter TEXT NOT NULL,
+   enabled INTEGER NOT NULL,
+   updated_at INTEGER NOT NULL
+);

--- a/app/src/test/java/com/jjswigut/eventide/network/service/NoaaServiceImplTest.kt
+++ b/app/src/test/java/com/jjswigut/eventide/network/service/NoaaServiceImplTest.kt
@@ -1,0 +1,66 @@
+package com.jjswigut.eventide.network.service
+
+import com.jjswigut.eventide.network.client.NoaaServiceClient
+import com.jjswigut.eventide.network.utils.Either
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NoaaServiceImplTest {
+    @Test
+    fun `tide request recovers from transient NOAA error payload`() = runTest {
+        var requestCount = 0
+        val requestedUrls = mutableListOf<String>()
+        val engine = MockEngine { request ->
+            requestCount += 1
+            requestedUrls += request.url.toString()
+            respond(
+                content = if (requestCount == 1) noaaErrorPayload else predictionsPayload,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val service = NoaaServiceImpl(NoaaServiceClient(engine))
+
+        val result = service.getTidesForStation("8461490")
+
+        assertTrue("Expected Eventide to recover from NOAA's transient error, got $result", result is Either.Success)
+        result as Either.Success
+        assertEquals(2, result.value.predictions.size)
+        assertEquals(2, requestCount)
+        assertTrue(requestedUrls.first().contains("application=Eventide"))
+        assertTrue(requestedUrls.first().contains("end_date="))
+        assertTrue(requestedUrls.last().contains("range=192"))
+    }
+
+    @Test
+    fun `tide request returns failure after bounded NOAA error retries`() = runTest {
+        var requestCount = 0
+        val engine = MockEngine {
+            requestCount += 1
+            respond(
+                content = noaaErrorPayload,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val service = NoaaServiceImpl(NoaaServiceClient(engine))
+
+        val result = service.getTidesForStation("8461490")
+
+        assertTrue(result is Either.Failure)
+        assertEquals(3, requestCount)
+    }
+}
+
+private const val noaaErrorPayload =
+    """{"error":{"message":"No Predictions data was found. Please make sure the Datum input is valid."}}"""
+
+private const val predictionsPayload =
+    """{"predictions":[{"t":"2026-07-18 00:46","v":"0.937","type":"H"},{"t":"2026-07-18 07:24","v":"0.017","type":"L"}]}"""

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -22,7 +22,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                   // Allow overriding versionCode from gradle properties, default to 13 if not provided
                   versionCode =
                     (project.findProperty("overrideVersionCode")?.toString()?.toIntOrNull()) ?: 13
-                  versionName = "2.04"
+                versionName = "2.05"
 
                     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
                     vectorDrawables {

--- a/release-notes/2.05.md
+++ b/release-notes/2.05.md
@@ -1,0 +1,1 @@
+Tide predictions now recover from temporary NOAA service errors instead of immediately showing unavailable. Eventide recognizes NOAA's documented error response, retries with a supported alternate date-range request, and spaces retries to respect NOAA API guidance.

--- a/release-notes/2.05.md
+++ b/release-notes/2.05.md
@@ -1,1 +1,1 @@
-Tide predictions now recover from temporary NOAA service errors instead of immediately showing unavailable. Eventide recognizes NOAA's documented error response, retries with a supported alternate date-range request, and spaces retries to respect NOAA API guidance.
+Fixes a startup crash affecting existing installs after updating to the latest Eventide release. Tide predictions also recover from temporary NOAA service errors instead of immediately showing unavailable, with bounded retries and a supported alternate date-range request.

--- a/tools/eventide_verify.sh
+++ b/tools/eventide_verify.sh
@@ -9,6 +9,8 @@ source "${SCRIPT_DIR}/eventide_env.sh"
 
 cd "${REPO_ROOT}"
 
+python3 tools/verify_database_migrations.py
+
 ./gradlew \
   :app:compileDebugKotlin \
   :app:spotlessCheck \

--- a/tools/verify_database_migrations.py
+++ b/tools/verify_database_migrations.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Verify that an existing Eventide database upgrades to the current schema."""
+
+from pathlib import Path
+import sqlite3
+import tempfile
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MIGRATION = (
+    REPO_ROOT
+    / "app/src/main/sqldelight/com/jjswigut/eventide/db/1.sqm"
+)
+
+
+def create_legacy_database(connection: sqlite3.Connection) -> None:
+    connection.executescript(
+        """
+        CREATE TABLE StationEntity (
+            id TEXT PRIMARY KEY,
+            latitude REAL NOT NULL,
+            longitude REAL NOT NULL,
+            name TEXT NOT NULL,
+            state TEXT NOT NULL
+        );
+        CREATE INDEX index_lat_lng ON StationEntity(latitude, longitude);
+        CREATE TABLE LastUpdate (
+            id INTEGER PRIMARY KEY,
+            lastUpdated INTEGER
+        );
+        PRAGMA user_version = 1;
+        """
+    )
+
+
+def apply_migration(connection: sqlite3.Connection) -> None:
+    if not MIGRATION.is_file():
+        raise AssertionError(f"Missing SQLDelight migration: {MIGRATION.relative_to(REPO_ROOT)}")
+
+    connection.executescript(MIGRATION.read_text(encoding="utf-8"))
+
+
+def assert_current_tables_are_usable(connection: sqlite3.Connection) -> None:
+    tables = {
+        row[0]
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        )
+    }
+    expected = {
+        "StationEntity",
+        "LastUpdate",
+        "FavoriteStationEntity",
+        "TideAlertPreferenceEntity",
+    }
+    if not expected.issubset(tables):
+        raise AssertionError(f"Migration missing tables: {sorted(expected - tables)}")
+
+    connection.execute(
+        """
+        INSERT INTO FavoriteStationEntity
+            (id, latitude, longitude, name, state, created_at)
+        VALUES ('8461490', 41.3614, -72.09, 'New London', 'CT', 1)
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO TideAlertPreferenceEntity
+            (station_id, lead_time_minutes, tide_filter, enabled, updated_at)
+        VALUES ('8461490', 60, 'both', 1, 1)
+        """
+    )
+    assert connection.execute(
+        "SELECT COUNT(*) FROM FavoriteStationEntity"
+    ).fetchone() == (1,)
+    assert connection.execute(
+        "SELECT COUNT(*) FROM TideAlertPreferenceEntity"
+    ).fetchone() == (1,)
+
+
+def verify_upgrade() -> None:
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        database_path = Path(temp_dir) / "Stations.db"
+        with sqlite3.connect(database_path) as connection:
+            create_legacy_database(connection)
+            apply_migration(connection)
+            assert_current_tables_are_usable(connection)
+
+
+def verify_already_current_schema() -> None:
+    """Builds 23-27 created all tables but still recorded schema version 1."""
+    with sqlite3.connect(":memory:") as connection:
+        create_legacy_database(connection)
+        apply_migration(connection)
+        apply_migration(connection)
+        assert_current_tables_are_usable(connection)
+
+
+if __name__ == "__main__":
+    verify_upgrade()
+    verify_already_current_schema()
+    print("Database migration verification passed")


### PR DESCRIPTION
## Release
Eventide 2.05 fixes the Play Store upgrade crash and improves NOAA tide availability.

## Included
- migrate existing schema-version-1 databases to create favorites and tide-alert tables
- verify legacy and already-current database upgrade paths in local and CI gates
- recognize NOAA HTTP 200 error envelopes and retry tide requests with bounded delays and an alternate supported range request

## Proof
- feature PR #15 passed GitHub CI and merged to `develop`
- `tools/eventide_release_check.sh` passed locally
- forced emulator smoke passed with deterministic tide, weather, and marine content
- an in-place build 21 to 2.05 emulator upgrade advanced the database from schema version 1 to 2, created both missing tables, resumed Eventide `MainActivity`, and produced no fatal or missing-table errors
